### PR TITLE
경북대 BE_정성훈 5주차 과제 (0단계)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,100 @@
-# spring-gift-order
+## 1단계 - 상품 카테고리
+
+### 기능 요구 사항
+
+#### 카테고리 추가
+
+##### 카테고리 제한사항
+
+- 상품에는 항상 하나의 카테고리가 존재
+- 관리자 화면에서 상품 추가시 카테고리도 지정 필수
+- 1차 카테고리만 고려
+
+**Request**
+
+`GET /api/categories HTTP/1.1`
+
+**Response**
+
+```json
+[
+  {
+    "id": 91,
+    "name": "교환권",
+    "color": "#6c95d1",
+    "imageUrl": "https://gift-s.kakaocdn.net/dn/gift/images/m640/dimm_theme.png",
+    "description": ""
+  }
+]
+```
+
+### 프로그래밍 요구 사항
+
+- 구현한 기능들에대한 테스트 코드 작성
+
+@Test
+@DisplayName("생성된 날짜")
+void dateCheck() {
+
+        Member member = new Member("a@naver.com", "1234");
+        memberRepository.save(member);
+        Product product = productRepository.getReferenceById(1L);
+
+        Wish wish = new Wish(member, 100, product);
+
+        Wish save = wishRepository.save(wish);
+
+        assertThat(save.getCreatedTime())
+                .isInstanceOf(LocalDateTime.class);
+    }
+
+## 2단계 - 상품 옵션
+
+### 기능 요구 사항
+
+#### 옵션 추가
+
+##### 옵션 제한사항
+
+- 상품에는 항상 하나 이상의 옵션이 존재
+- 옵션 이름 공백 포함 최대 50자
+- 특수문자는 ( ), [ ], +, -, &, /, _ 만 가능
+- 옵션 수량은 최소 1 이상 1억 미만
+- 동일 상품 동일 옵션 이름 불가
+- (선택) 관리자 화면에서 옵션 추가가능
+
+##### 유의
+
+- 제한 사항 꼭 지키기
+- 제한사항 어길때의 테스트 적용해보기
+- 연관관계 적절히 구성
+
+### 프로그래밍 요구 사항
+
+- 구현한 기능들에대한 테스트 코드 작성
+
+## 3단계 - 옵션 수량 차감
+
+### 기능 요구 사항
+
+#### 옵션 수량 차감
+
+##### 수량을 지정된 숫자만큼 빼기
+
+- 차감 숫자 > 남은 상품 숫자 일때 예외 처리
+- 서비스와 엔티티에서 기능을 구현
+
+### 프로그래밍 요구 사항
+
+- 테스트 전략
+    - 컨트롤러가 없어도 되는만큼 만들어진 요소들을 모두 단위 테스트에 적합할듯함
+
+## 4단계 - 동시성 테스트
+
+### 기능 요구 사항
+
+#### 1개 남았을때 동시에 차감 요청이 오는 경우
+
+- 차감 숫자 > 남은 상품 숫자 일때 예외 처리를 3단계에서 구현
+- 동시성에 대한 테스트 코드 먼저 작성후 이를 기반으로 동시성 문제 발생을 확인
+- 동시성 해결 방법에대한 여러 방법이 존재. 이를 분석해보고 적절한것으로 구현

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,17 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    runtimeOnly 'com.h2database:h2'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/gift/Application.java
+++ b/src/main/java/gift/Application.java
@@ -2,8 +2,10 @@ package gift;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class Application {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -1,0 +1,31 @@
+package gift.config;
+
+import gift.interceptor.AuthInterceptor;
+import gift.interceptor.MemberIdArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
+    public WebConfig(AuthInterceptor authInterceptor) {
+        this.authInterceptor = authInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor).addPathPatterns("/api/wishlist/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new MemberIdArgumentResolver());
+    }
+
+}

--- a/src/main/java/gift/controller/admin/ProductAdminController.java
+++ b/src/main/java/gift/controller/admin/ProductAdminController.java
@@ -1,0 +1,86 @@
+package gift.controller.admin;
+
+import gift.dto.request.AddProductRequest;
+import gift.dto.request.UpdateProductRequest;
+import gift.entity.Product;
+import gift.service.CategoryService;
+import gift.service.ProductService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+public class ProductAdminController {
+
+    private final ProductService productService;
+    private final CategoryService categoryService;
+
+    public ProductAdminController(ProductService productService, CategoryService categoryService) {
+        this.productService = productService;
+        this.categoryService = categoryService;
+    }
+
+
+    @GetMapping("/")
+    public String getProducts(Model model, @PageableDefault(sort = "id") Pageable pageable) {
+        model.addAttribute("products", productService.getProductResponses(pageable));
+        return "version-SSR/index";
+    }
+
+    @GetMapping("/add")
+    public String getAddForm(Model model) {
+        model.addAttribute("addProductRequest", new AddProductRequest("", 0, "", 0L, new ArrayList<>()));
+        model.addAttribute("categories", categoryService.getAllCategoryResponses());
+        return "version-SSR/add-form";
+    }
+
+    @PostMapping("/add")
+    public String addProduct(@Valid AddProductRequest request) {
+        try {
+            productService.addProduct(request);
+            return "redirect:/";
+        } catch (Exception e) {
+            return "version-SSR/add-error";
+        }
+    }
+
+    @PostMapping("/deleteSelected")
+    public String deleteSelectedProduct(@RequestParam("productIds") List<Long> productIds) {
+        productService.deleteProducts(productIds);
+        return "redirect:/";
+    }
+
+    @PostMapping("/delete")
+    public String deleteProduct(@RequestParam("productId") Long productId) {
+        productService.deleteProduct(productId);
+        return "redirect:/";
+    }
+
+    @GetMapping("/edit/{id}")
+    public String getEditForm(@PathVariable("id") long id, Model model) {
+        Product existingProduct = productService.getProduct(id);
+        model.addAttribute("updateProductRequest", new UpdateProductRequest(existingProduct.getId(), existingProduct.getName(), existingProduct.getPrice(), existingProduct.getImageUrl(), existingProduct.getId()));
+        model.addAttribute("categories", categoryService.getAllCategoryResponses());
+        return "version-SSR/edit-form";
+    }
+
+    @PostMapping("/edit")
+    public String editProduct(@Valid UpdateProductRequest request) {
+        try {
+            productService.updateProduct(request);
+            return "redirect:/";
+        } catch (Exception e) {
+            return "version-SSR/edit-error";
+        }
+    }
+
+}

--- a/src/main/java/gift/controller/advice/AdminGlobalExceptionHandler.java
+++ b/src/main/java/gift/controller/advice/AdminGlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package gift.controller.advice;
+
+import org.springframework.ui.Model;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.List;
+
+@ControllerAdvice(basePackages = "gift.controller.admin")
+public class AdminGlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public String handleValidationExceptions(MethodArgumentNotValidException e, Model model) {
+        List<String> invalidReasonList = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .toList();
+        model.addAttribute("invalidReasons", invalidReasonList);
+
+        return "version-SSR/product-error";
+    }
+
+}

--- a/src/main/java/gift/controller/advice/ApiGlobalExceptionHandler.java
+++ b/src/main/java/gift/controller/advice/ApiGlobalExceptionHandler.java
@@ -1,0 +1,80 @@
+package gift.controller.advice;
+
+import gift.exception.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice(basePackages = "gift.controller.api")
+public class ApiGlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ProblemDetail handleValidationExceptions(MethodArgumentNotValidException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        problemDetail.setTitle("Validation fail");
+
+        List<String> invalidReasonList = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.toList());
+        problemDetail.setProperty("invalidReasons", invalidReasonList);
+
+        return problemDetail;
+    }
+
+    @ExceptionHandler(MemberNotFoundException.class)
+    public ProblemDetail handleMemberNotFoundException(MemberNotFoundException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        problemDetail.setTitle(e.getMessage());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(EmailDuplicateException.class)
+    public ProblemDetail handleEmailDuplicateException(EmailDuplicateException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        problemDetail.setTitle(e.getMessage());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(ProductNotFoundException.class)
+    public ProblemDetail handleProductNotFoundExceptions(ProductNotFoundException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        problemDetail.setTitle(e.getMessage());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(WishAlreadyExistsException.class)
+    public ProblemDetail handleWishAlreadyExistsException(WishAlreadyExistsException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        problemDetail.setTitle(e.getMessage());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(WishNotFoundException.class)
+    public ProblemDetail handleWishNotFoundException(WishNotFoundException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        problemDetail.setTitle(e.getMessage());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(CategoryNotFoundException.class)
+    public ProblemDetail handleCategoryNotFoundException(CategoryNotFoundException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        problemDetail.setTitle(e.getMessage());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(OptionDuplicateException.class)
+    public ProblemDetail handleOptionDuplicateException(OptionDuplicateException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+        problemDetail.setTitle(e.getMessage());
+        return problemDetail;
+    }
+}

--- a/src/main/java/gift/controller/api/CategoryController.java
+++ b/src/main/java/gift/controller/api/CategoryController.java
@@ -1,0 +1,47 @@
+package gift.controller.api;
+
+import gift.dto.request.AddCategoryRequest;
+import gift.dto.request.UpdateCategoryRequest;
+import gift.dto.response.CategoryIdResponse;
+import gift.dto.response.CategoryResponse;
+import gift.service.CategoryService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @PostMapping("/api/categories")
+    public ResponseEntity<CategoryIdResponse> addCategory(@Valid @RequestBody AddCategoryRequest request) {
+        CategoryIdResponse categoryIdResponse = categoryService.addCategory(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(categoryIdResponse);
+    }
+
+    @GetMapping("/api/categories")
+    public ResponseEntity<List<CategoryResponse>> getCategories() {
+        List<CategoryResponse> allCategories = categoryService.getAllCategoryResponses();
+        return ResponseEntity.ok(allCategories);
+    }
+
+    @PutMapping("/api/categories")
+    public ResponseEntity<Void> updateCategory(@Valid @RequestBody UpdateCategoryRequest request) {
+        categoryService.updateCategory(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/api/categories/{id}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable("id") Long categoryId) {
+        categoryService.deleteCategory(categoryId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/gift/controller/api/MemberController.java
+++ b/src/main/java/gift/controller/api/MemberController.java
@@ -1,0 +1,37 @@
+package gift.controller.api;
+
+import gift.dto.request.MemberRequest;
+import gift.dto.response.TokenResponse;
+import gift.service.MemberService;
+import gift.service.TokenService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+    private final TokenService tokenService;
+
+    public MemberController(MemberService memberService, TokenService tokenService) {
+        this.memberService = memberService;
+        this.tokenService = tokenService;
+    }
+
+    @PostMapping("/members/register")
+    public ResponseEntity<TokenResponse> registerMember(@Valid @RequestBody MemberRequest request) {
+        Long registeredMemberId = memberService.register(request);
+        TokenResponse token = tokenService.generateToken(registeredMemberId);
+        return ResponseEntity.ok(token);
+    }
+
+    @PostMapping("/members/login")
+    public ResponseEntity<TokenResponse> loginMember(@Valid @RequestBody MemberRequest request) {
+        Long registeredMemberId = memberService.login(request);
+        TokenResponse token = tokenService.generateToken(registeredMemberId);
+        return ResponseEntity.ok(token);
+    }
+}

--- a/src/main/java/gift/controller/api/ProductController.java
+++ b/src/main/java/gift/controller/api/ProductController.java
@@ -1,0 +1,65 @@
+package gift.controller.api;
+
+import gift.dto.request.AddProductRequest;
+import gift.dto.request.OptionRequest;
+import gift.dto.request.UpdateProductRequest;
+import gift.dto.response.AddedOptionIdResponse;
+import gift.dto.response.AddedProductIdResponse;
+import gift.dto.response.OptionResponse;
+import gift.dto.response.ProductResponse;
+import gift.service.ProductService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class ProductController {
+
+    private final ProductService productService;
+
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
+
+    @PostMapping("api/products")
+    public ResponseEntity<AddedProductIdResponse> addProduct(@Valid @RequestBody AddProductRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(productService.addProduct(request));
+    }
+
+    @GetMapping("api/products")
+    public ResponseEntity<Page<ProductResponse>> getProducts(@PageableDefault(sort = "id") Pageable pageable) {
+        Page<ProductResponse> productResponses = productService.getProductResponses(pageable);
+        return ResponseEntity.ok(productResponses);
+    }
+
+    @PutMapping("api/products")
+    public ResponseEntity<Void> updateProduct(@Valid @RequestBody UpdateProductRequest request) {
+        productService.updateProduct(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("api/products/{id}")
+    public ResponseEntity<Void> deleteProduct(@PathVariable("id") Long id) {
+        productService.deleteProduct(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("api/products/{id}/options")
+    public ResponseEntity<List<OptionResponse>> getOptionResponses(@PathVariable("id") Long productId) {
+        return ResponseEntity.ok(productService.getOptionResponses(productId));
+    }
+
+    @PostMapping("api/products/{id}/options")
+    public ResponseEntity<AddedOptionIdResponse> addOptionToProduct(@PathVariable("id") Long productId,
+                                                                    @Valid @RequestBody OptionRequest optionRequest) {
+        AddedOptionIdResponse addedOptionId = productService.addOptionToProduct(productId, optionRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(addedOptionId);
+    }
+}

--- a/src/main/java/gift/controller/api/WishController.java
+++ b/src/main/java/gift/controller/api/WishController.java
@@ -1,0 +1,48 @@
+package gift.controller.api;
+
+import gift.dto.request.WishRequest;
+import gift.dto.response.WishProductResponse;
+import gift.interceptor.MemberId;
+import gift.service.WishService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class WishController {
+
+    private final WishService wishService;
+
+    public WishController(WishService wishService) {
+        this.wishService = wishService;
+    }
+
+    @PostMapping("api/wishlist")
+    public ResponseEntity<Void> addProductToWish(@MemberId Long memberId, @Valid @RequestBody WishRequest request) {
+        wishService.addProductToWish(memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("api/wishlist")
+    public ResponseEntity<Page<WishProductResponse>> getWishProducts(@MemberId Long memberId, @PageableDefault(sort = "createdTime", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<WishProductResponse> wishProductResponses = wishService.getWishProductResponses(memberId, pageable);
+        return ResponseEntity.ok(wishProductResponses);
+    }
+
+    @PutMapping("api/wishlist")
+    public ResponseEntity<Void> updateWishProductQuantity(@MemberId Long memberId, @Valid @RequestBody WishRequest request) {
+        wishService.updateWishProductQuantity(memberId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("api/wishlist/{id}")
+    public ResponseEntity<Void> deleteWishProduct(@MemberId Long memberId, @PathVariable("id") Long productId) {
+        wishService.deleteProductInWish(memberId, productId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/gift/dto/request/AddCategoryRequest.java
+++ b/src/main/java/gift/dto/request/AddCategoryRequest.java
@@ -1,0 +1,14 @@
+package gift.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AddCategoryRequest(
+        @NotBlank
+        String name,
+        @NotBlank
+        String color,
+        @NotBlank
+        String imageUrl,
+        String description
+) {
+}

--- a/src/main/java/gift/dto/request/AddProductRequest.java
+++ b/src/main/java/gift/dto/request/AddProductRequest.java
@@ -1,0 +1,30 @@
+package gift.dto.request;
+
+import gift.validation.ContainsOnlyAllowedSpecialCharacter;
+import gift.validation.NotContainsKakao;
+import gift.validation.UniqueOptionNames;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record AddProductRequest(
+        @NotBlank
+        @Size(max = 15, message = "상품 이름은 공백을 포함하여 최대 15자까지 입력할 수 있습니다.")
+        @NotContainsKakao(message = "상품 이름에 `카카오`가 포함된 문구는 담당 MD와 협의한 경우에만 사용 가능합니다.")
+        @ContainsOnlyAllowedSpecialCharacter(message = "상품 이름에 (, ), [, ], +, -, &, /, _ 와 같은 특수문자만 허용됩니다.")
+        String name,
+        @NotNull
+        int price,
+        @NotBlank
+        String imageUrl,
+        @NotNull
+        Long categoryId,
+        @Valid
+        @Size(min = 1, message = "상품에는 하나 이상의 옵션이 있어야합니다.")
+        @UniqueOptionNames(message = "상품의 옵션 이름은 중복될 수 없습니다.")
+        List<OptionRequest> optionRequests
+) {
+}

--- a/src/main/java/gift/dto/request/MemberRequest.java
+++ b/src/main/java/gift/dto/request/MemberRequest.java
@@ -1,0 +1,14 @@
+package gift.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberRequest(
+        @NotBlank(message = "email 값은 공백일 수 없습니다.")
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        String email,
+
+        @NotBlank(message = "password 값은 공백일 수 없습니다.")
+        String password
+) {
+}

--- a/src/main/java/gift/dto/request/OptionRequest.java
+++ b/src/main/java/gift/dto/request/OptionRequest.java
@@ -1,0 +1,16 @@
+package gift.dto.request;
+
+import gift.validation.ContainsOnlyAllowedSpecialCharacter;
+import jakarta.validation.constraints.*;
+
+public record OptionRequest(
+        @NotBlank(message = "옵션 이름을 입력해주세요.")
+        @Size(max = 50, message = "옵션 이름은 공백을 포함하여 최대 50자까지 입력할 수 있습니다.")
+        @ContainsOnlyAllowedSpecialCharacter(message = "옵션 이름에 (, ), [, ], +, -, &, /, _ 와 같은 특수문자만 허용됩니다.")
+        String name,
+        @NotNull(message = "옵션 수량을 입력해주세요.")
+        @Min(value = 1, message = "옵션 수량은 최소 1개 이상이어야 합니다.")
+        @Max(value = 99999999, message = "옵션 수량은 1억 개 미만이어야 합니다.")
+        Integer quantity
+) {
+}

--- a/src/main/java/gift/dto/request/UpdateCategoryRequest.java
+++ b/src/main/java/gift/dto/request/UpdateCategoryRequest.java
@@ -1,0 +1,17 @@
+package gift.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateCategoryRequest(
+        @NotNull
+        Long id,
+        @NotBlank
+        String name,
+        @NotBlank
+        String color,
+        @NotBlank
+        String imageUrl,
+        String description
+) {
+}

--- a/src/main/java/gift/dto/request/UpdateProductRequest.java
+++ b/src/main/java/gift/dto/request/UpdateProductRequest.java
@@ -1,0 +1,24 @@
+package gift.dto.request;
+
+import gift.validation.ContainsOnlyAllowedSpecialCharacter;
+import gift.validation.NotContainsKakao;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateProductRequest(
+        @NotNull
+        Long id,
+        @NotBlank
+        @Size(max = 15, message = "상품 이름은 공백을 포함하여 최대 15자까지 입력할 수 있습니다.")
+        @NotContainsKakao(message = "상품 이름에 `카카오`가 포함된 문구는 담당 MD와 협의한 경우에만 사용 가능합니다.")
+        @ContainsOnlyAllowedSpecialCharacter(message = "상품 이름에 (, ), [, ], +, -, &, /, _ 와 같은 특수문자만 허용됩니다.")
+        String name,
+        @NotNull
+        int price,
+        @NotBlank
+        String imageUrl,
+        @NotNull
+        Long categoryId
+) {
+}

--- a/src/main/java/gift/dto/request/WishRequest.java
+++ b/src/main/java/gift/dto/request/WishRequest.java
@@ -1,0 +1,11 @@
+package gift.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record WishRequest(
+        @NotNull
+        Long productId,
+        @NotNull
+        int quantity
+) {
+}

--- a/src/main/java/gift/dto/response/AddedOptionIdResponse.java
+++ b/src/main/java/gift/dto/response/AddedOptionIdResponse.java
@@ -1,0 +1,6 @@
+package gift.dto.response;
+
+public record AddedOptionIdResponse(
+        Long optionId
+) {
+}

--- a/src/main/java/gift/dto/response/AddedProductIdResponse.java
+++ b/src/main/java/gift/dto/response/AddedProductIdResponse.java
@@ -1,0 +1,6 @@
+package gift.dto.response;
+
+public record AddedProductIdResponse(
+        Long id
+) {
+}

--- a/src/main/java/gift/dto/response/CategoryIdResponse.java
+++ b/src/main/java/gift/dto/response/CategoryIdResponse.java
@@ -1,0 +1,6 @@
+package gift.dto.response;
+
+public record CategoryIdResponse(
+        Long id
+) {
+}

--- a/src/main/java/gift/dto/response/CategoryResponse.java
+++ b/src/main/java/gift/dto/response/CategoryResponse.java
@@ -1,0 +1,22 @@
+package gift.dto.response;
+
+import gift.entity.Category;
+
+public record CategoryResponse(
+        Long id,
+        String name,
+        String color,
+        String imageUrl,
+        String description
+
+) {
+    public static CategoryResponse fromCategory(Category category) {
+        return new CategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getColor(),
+                category.getImageUrl(),
+                category.getDescription()
+        );
+    }
+}

--- a/src/main/java/gift/dto/response/OptionResponse.java
+++ b/src/main/java/gift/dto/response/OptionResponse.java
@@ -1,0 +1,17 @@
+package gift.dto.response;
+
+import gift.entity.Option;
+
+public record OptionResponse(
+        Long id,
+        String name,
+        Integer quantity
+) {
+    public static OptionResponse fromOption(Option option) {
+        return new OptionResponse(
+                option.getId(),
+                option.getName(),
+                option.getQuantity()
+        );
+    }
+}

--- a/src/main/java/gift/dto/response/ProductResponse.java
+++ b/src/main/java/gift/dto/response/ProductResponse.java
@@ -1,0 +1,21 @@
+package gift.dto.response;
+
+import gift.entity.Product;
+
+public record ProductResponse(
+        Long id,
+        String name,
+        Integer price,
+        String imageUrl,
+        String categoryName
+) {
+    public static ProductResponse fromProduct(Product product) {
+        return new ProductResponse(
+                product.getId(),
+                product.getName(),
+                product.getPrice(),
+                product.getImageUrl(),
+                product.getCategory().getName()
+        );
+    }
+}

--- a/src/main/java/gift/dto/response/TokenResponse.java
+++ b/src/main/java/gift/dto/response/TokenResponse.java
@@ -1,0 +1,6 @@
+package gift.dto.response;
+
+public record TokenResponse(
+        String token
+) {
+}

--- a/src/main/java/gift/dto/response/WishProductResponse.java
+++ b/src/main/java/gift/dto/response/WishProductResponse.java
@@ -1,0 +1,21 @@
+package gift.dto.response;
+
+import gift.entity.Wish;
+
+public record WishProductResponse(
+        Long productId,
+        String productName,
+        int productPrice,
+        String productImageUrl,
+        int productAmount
+) {
+    public static WishProductResponse fromWish(Wish wish) {
+        return new WishProductResponse(
+                wish.getProduct().getId(),
+                wish.getProduct().getName(),
+                wish.getProduct().getPrice(),
+                wish.getProduct().getImageUrl(),
+                wish.getQuantity()
+        );
+    }
+}

--- a/src/main/java/gift/entity/Category.java
+++ b/src/main/java/gift/entity/Category.java
@@ -1,0 +1,59 @@
+package gift.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    @Column(nullable = false, length = 7)
+    private String color;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    private String description;
+
+    protected Category() {
+    }
+
+    public Category(String name, String color, String imageUrl, String description) {
+        this.name = name;
+        this.color = color;
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+
+    public void update(String name, String color, String imageUrl, String description) {
+        this.name = name;
+        this.color = color;
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -1,0 +1,33 @@
+package gift.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    public Member(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    protected Member() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/gift/entity/Option.java
+++ b/src/main/java/gift/entity/Option.java
@@ -1,0 +1,53 @@
+package gift.entity;
+
+import gift.exception.InsufficientOptionQuantityException;
+import jakarta.persistence.*;
+
+@Entity
+public class Option {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", foreignKey = @ForeignKey(name = "fk_option_product_id_ref_product_id"))
+    private Product product;
+
+    protected Option() {
+    }
+
+    public Option(String name, Integer quantity) {
+        this.name = name;
+        this.quantity = quantity;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void associateWithProduct(Product product) {
+        this.product = product;
+    }
+
+    public void subtract(int subtractQuantity) {
+        if (this.quantity < subtractQuantity) {
+            throw new InsufficientOptionQuantityException(subtractQuantity);
+        }
+        this.quantity -= subtractQuantity;
+    }
+}

--- a/src/main/java/gift/entity/Option.java
+++ b/src/main/java/gift/entity/Option.java
@@ -50,4 +50,8 @@ public class Option {
         }
         this.quantity -= subtractQuantity;
     }
+
+    public boolean isSameName(String newOptionName) {
+        return name.equals(newOptionName);
+    }
 }

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -1,0 +1,84 @@
+package gift.entity;
+
+import gift.exception.OptionDuplicateException;
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Product {
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private final List<Option> options = new ArrayList<>();
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, length = 15)
+    private String name;
+    @Column(nullable = false)
+    private Integer price;
+    @Column(nullable = false)
+    private String imageUrl;
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false, foreignKey = @ForeignKey(name = "fk_product_category_id_ref_category_id"))
+    private Category category;
+
+    protected Product() {
+    }
+
+    public Product(String name, Integer price, String imageUrl, Category category, List<Option> options) {
+        this.name = name;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.category = category;
+        this.options.addAll(options);
+        for (Option option : options) {
+            option.associateWithProduct(this);
+        }
+    }
+
+    public void addOption(Option option) {
+        options.add(option);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getPrice() {
+        return price;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public List<Option> getOptions() {
+        return options;
+    }
+
+    public void update(String name, int price, String imageUrl, Category category) {
+        this.name = name;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.category = category;
+    }
+
+    public void checkDuplicateOptionName(String newOptionName) {
+        boolean isDuplicate = options.stream()
+                .anyMatch(option -> option.getName().equals(newOptionName));
+
+        if (isDuplicate) {
+            throw new OptionDuplicateException(newOptionName);
+        }
+    }
+}

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -39,7 +39,10 @@ public class Product {
     }
 
     public void addOption(Option option) {
+        checkDuplicateOptionName(option.getName());
+
         options.add(option);
+        option.associateWithProduct(this);
     }
 
     public Long getId() {

--- a/src/main/java/gift/entity/Product.java
+++ b/src/main/java/gift/entity/Product.java
@@ -75,7 +75,7 @@ public class Product {
 
     public void checkDuplicateOptionName(String newOptionName) {
         boolean isDuplicate = options.stream()
-                .anyMatch(option -> option.getName().equals(newOptionName));
+                .anyMatch(option -> option.isSameName(newOptionName));
 
         if (isDuplicate) {
             throw new OptionDuplicateException(newOptionName);

--- a/src/main/java/gift/entity/Wish.java
+++ b/src/main/java/gift/entity/Wish.java
@@ -1,0 +1,60 @@
+package gift.entity;
+
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Wish {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_wish_member_id_ref_member_id"))
+    private Member member;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @ManyToOne
+    @JoinColumn(name = "product_id", nullable = false, foreignKey = @ForeignKey(name = "fk_wish_product_id_ref_product_id"))
+    private Product product;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdTime;
+
+    public Wish(Member member, Integer quantity, Product product) {
+        this.member = member;
+        this.quantity = quantity;
+        this.product = product;
+    }
+
+    protected Wish() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public LocalDateTime getCreatedTime() {
+        return createdTime;
+    }
+
+    public void updateQuantity(Integer amount) {
+        this.quantity = amount;
+    }
+}

--- a/src/main/java/gift/exception/CategoryNameDuplicateException.java
+++ b/src/main/java/gift/exception/CategoryNameDuplicateException.java
@@ -1,0 +1,7 @@
+package gift.exception;
+
+public class CategoryNameDuplicateException extends RuntimeException {
+    public CategoryNameDuplicateException(String duplicatedName) {
+        super(duplicatedName + " already in use");
+    }
+}

--- a/src/main/java/gift/exception/CategoryNotFoundException.java
+++ b/src/main/java/gift/exception/CategoryNotFoundException.java
@@ -1,0 +1,8 @@
+package gift.exception;
+
+public class CategoryNotFoundException extends RuntimeException {
+
+    public CategoryNotFoundException(Long categoryId) {
+        super("CategoryId: " + categoryId + " not found");
+    }
+}

--- a/src/main/java/gift/exception/EmailDuplicateException.java
+++ b/src/main/java/gift/exception/EmailDuplicateException.java
@@ -1,0 +1,8 @@
+package gift.exception;
+
+public class EmailDuplicateException extends RuntimeException {
+
+    public EmailDuplicateException(String email) {
+        super(email + " already in use");
+    }
+}

--- a/src/main/java/gift/exception/InsufficientOptionQuantityException.java
+++ b/src/main/java/gift/exception/InsufficientOptionQuantityException.java
@@ -1,0 +1,7 @@
+package gift.exception;
+
+public class InsufficientOptionQuantityException extends RuntimeException {
+    public InsufficientOptionQuantityException(int quantity) {
+        super("Existing quantity is less than " + quantity);
+    }
+}

--- a/src/main/java/gift/exception/MemberNotFoundException.java
+++ b/src/main/java/gift/exception/MemberNotFoundException.java
@@ -1,0 +1,9 @@
+package gift.exception;
+
+public class MemberNotFoundException extends RuntimeException {
+
+    public MemberNotFoundException() {
+        super("Member not found");
+    }
+
+}

--- a/src/main/java/gift/exception/OptionDuplicateException.java
+++ b/src/main/java/gift/exception/OptionDuplicateException.java
@@ -1,0 +1,7 @@
+package gift.exception;
+
+public class OptionDuplicateException extends RuntimeException {
+    public OptionDuplicateException(String duplicatedName) {
+        super(duplicatedName + " is duplicated");
+    }
+}

--- a/src/main/java/gift/exception/OptionNotFoundException.java
+++ b/src/main/java/gift/exception/OptionNotFoundException.java
@@ -1,0 +1,7 @@
+package gift.exception;
+
+public class OptionNotFoundException extends RuntimeException {
+    public OptionNotFoundException(Long optionId) {
+        super("OptionId: " + optionId + " not found.");
+    }
+}

--- a/src/main/java/gift/exception/ProductNotFoundException.java
+++ b/src/main/java/gift/exception/ProductNotFoundException.java
@@ -1,0 +1,9 @@
+package gift.exception;
+
+public class ProductNotFoundException extends RuntimeException {
+
+    public ProductNotFoundException() {
+        super("Product not found");
+    }
+
+}

--- a/src/main/java/gift/exception/WishAlreadyExistsException.java
+++ b/src/main/java/gift/exception/WishAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package gift.exception;
+
+public class WishAlreadyExistsException extends RuntimeException {
+
+    public WishAlreadyExistsException(Long productId) {
+        super("ProductId: " + productId + " already exist in your wishlist");
+    }
+}

--- a/src/main/java/gift/exception/WishNotFoundException.java
+++ b/src/main/java/gift/exception/WishNotFoundException.java
@@ -1,0 +1,9 @@
+package gift.exception;
+
+public class WishNotFoundException extends RuntimeException {
+
+    public WishNotFoundException() {
+        super("Wish not found");
+    }
+
+}

--- a/src/main/java/gift/initializer/InitialData.java
+++ b/src/main/java/gift/initializer/InitialData.java
@@ -1,0 +1,81 @@
+package gift.initializer;
+
+import gift.entity.Category;
+import gift.entity.Option;
+import gift.entity.Product;
+import gift.repository.CategoryRepository;
+import gift.repository.ProductRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class InitialData implements CommandLineRunner {
+
+    private final ProductRepository productRepository;
+    private final CategoryRepository categoryRepository;
+
+    public InitialData(ProductRepository productRepository, CategoryRepository categoryRepository) {
+        this.productRepository = productRepository;
+        this.categoryRepository = categoryRepository;
+    }
+
+    @Override
+    public void run(String... args) {
+        initialCategory();
+        initialProduct();
+    }
+
+    private void initialCategory() {
+        categoryRepository.save(new Category("교환권", "color", "imageUrl", "description"));
+        categoryRepository.save(new Category("상품권", "color", "imageUrl", "description"));
+        categoryRepository.save(new Category("뷰티", "color", "imageUrl", "description"));
+        categoryRepository.save(new Category("패션", "color", "imageUrl", "description"));
+        categoryRepository.save(new Category("리빙/도서", "color", "imageUrl", "description"));
+        categoryRepository.save(new Category("레저/스포츠", "color", "imageUrl", "description"));
+        categoryRepository.save(new Category("아티스트/캐릭터", "color", "imageUrl", "description"));
+        categoryRepository.save(new Category("유아동/반려", "color", "imageUrl", "description"));
+        categoryRepository.save(new Category("디지털/가전", "color", "imageUrl", "description"));
+        categoryRepository.save(new Category("카카오프렌즈", "color", "imageUrl", "description"));
+        categoryRepository.save(new Category("트랜드 선물", "color", "imageUrl", "description"));
+        categoryRepository.save(new Category("백화점", "color", "imageUrl", "description"));
+    }
+
+    private void initialProduct() {
+
+        productRepository.save(new Product(
+                "Ice Americano",
+                4500,
+                "https://st.kakaocdn.net/product/gift/product/20231010111814_9a667f9eccc943648797925498bdd8a3.jpg",
+                categoryRepository.getReferenceById(1L),
+                List.of(
+                        new Option("Tall", 1000),
+                        new Option("Small", 123),
+                        new Option("Grande", 500))));
+        productRepository.save(new Product(
+                "Latte",
+                5500,
+                "https://cdn.pixabay.com/photo/2023/07/08/13/17/coffee-8114518_1280.png",
+                categoryRepository.getReferenceById(1L),
+                List.of(
+                        new Option("Tall", 12),
+                        new Option("Grande", 4))));
+        productRepository.save(new Product(
+                "Chair",
+                150000,
+                "https://i5.walmartimages.com/seo/Ktaxon-Modern-Single-Sofa-Chair-Club-Chairs-with-Side-Bags-Fabric-Arm-Chair-with-Wood-Legs-for-Living-Room-Bed-Room-Navy-Blue_088241ad-b15b-459c-9555-ef39fb140029.ac38734266e6fcb1f82674b61a537aca.jpeg",
+                categoryRepository.getReferenceById(5L),
+                List.of(
+                        new Option("Big", 99939),
+                        new Option("Small", 1))));
+        productRepository.save(new Product(
+                "Ryan Figure",
+                10000,
+                "https://img.danawa.com/prod_img/500000/156/603/img/7603156_1.jpg?_v=20200720155431",
+                categoryRepository.getReferenceById(10L),
+                List.of(
+                        new Option("Plastic", 99939),
+                        new Option("Steel", 434535))));
+    }
+}

--- a/src/main/java/gift/interceptor/AuthInterceptor.java
+++ b/src/main/java/gift/interceptor/AuthInterceptor.java
@@ -1,0 +1,35 @@
+package gift.interceptor;
+
+import gift.service.TokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final TokenService tokenService;
+
+    public AuthInterceptor(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            response.setHeader("WWW-Authenticate", "Bearer");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+        String token = authHeader.substring("Bearer ".length()).trim();
+        if (!tokenService.isValidateToken(token)) {
+            response.setHeader("WWW-Authenticate", "Bearer");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+        request.setAttribute("memberId", tokenService.getMemberId(token));
+        return true;
+    }
+}

--- a/src/main/java/gift/interceptor/MemberId.java
+++ b/src/main/java/gift/interceptor/MemberId.java
@@ -1,0 +1,11 @@
+package gift.interceptor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface MemberId {
+}

--- a/src/main/java/gift/interceptor/MemberIdArgumentResolver.java
+++ b/src/main/java/gift/interceptor/MemberIdArgumentResolver.java
@@ -1,0 +1,23 @@
+package gift.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(MemberId.class) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        return (Long) request.getAttribute("memberId");
+    }
+
+}

--- a/src/main/java/gift/repository/CategoryRepository.java
+++ b/src/main/java/gift/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package gift.repository;
+
+import gift.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    boolean existsByName(String name);
+
+}

--- a/src/main/java/gift/repository/MemberRepository.java
+++ b/src/main/java/gift/repository/MemberRepository.java
@@ -1,0 +1,16 @@
+package gift.repository;
+
+import gift.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmailAndPassword(String email, String password);
+
+    Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
+}

--- a/src/main/java/gift/repository/OptionRepository.java
+++ b/src/main/java/gift/repository/OptionRepository.java
@@ -1,0 +1,18 @@
+package gift.repository;
+
+import gift.entity.Option;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface OptionRepository extends JpaRepository<Option, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM Option o WHERE o.id = :id")
+    Optional<Option> findByIdWithPessimisticWriteLock(@Param("id") Long id);
+
+}

--- a/src/main/java/gift/repository/ProductRepository.java
+++ b/src/main/java/gift/repository/ProductRepository.java
@@ -1,0 +1,12 @@
+package gift.repository;
+
+import gift.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    Page<Product> findAll(Pageable pageable);
+
+}

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -1,0 +1,19 @@
+package gift.repository;
+
+import gift.entity.Member;
+import gift.entity.Product;
+import gift.entity.Wish;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WishRepository extends JpaRepository<Wish, Long> {
+
+    Page<Wish> findAllByMember(Member member, Pageable pageable);
+
+    Optional<Wish> findByMemberAndProduct(Member member, Product product);
+
+    boolean existsByMemberAndProduct(Member member, Product product);
+}

--- a/src/main/java/gift/service/CategoryService.java
+++ b/src/main/java/gift/service/CategoryService.java
@@ -1,0 +1,65 @@
+package gift.service;
+
+import gift.dto.request.AddCategoryRequest;
+import gift.dto.request.UpdateCategoryRequest;
+import gift.dto.response.CategoryIdResponse;
+import gift.dto.response.CategoryResponse;
+import gift.entity.Category;
+import gift.exception.CategoryNameDuplicateException;
+import gift.exception.CategoryNotFoundException;
+import gift.repository.CategoryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public CategoryService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<CategoryResponse> getAllCategoryResponses() {
+        return categoryRepository.findAll()
+                .stream()
+                .map(CategoryResponse::fromCategory)
+                .toList();
+    }
+
+    public CategoryIdResponse addCategory(AddCategoryRequest request) {
+        if (categoryRepository.existsByName(request.name())) {
+            throw new CategoryNameDuplicateException(request.name());
+        }
+
+        Category newCategory = new Category(
+                request.name(),
+                request.color(),
+                request.imageUrl(),
+                request.description()
+        );
+
+        return new CategoryIdResponse(categoryRepository.save(newCategory).getId());
+    }
+
+    @Transactional
+    public void updateCategory(UpdateCategoryRequest request) {
+        Category updateTargetCategory = categoryRepository.findById(request.id())
+                .orElseThrow(() -> new CategoryNotFoundException(request.id()));
+        updateTargetCategory.update(request.name(), request.color(), request.imageUrl(), request.description());
+    }
+
+    public Category getCategory(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CategoryNotFoundException(categoryId));
+    }
+
+    public void deleteCategory(Long categoryId) {
+        Category deleteTargetCategory = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CategoryNotFoundException(categoryId));
+
+        categoryRepository.delete(deleteTargetCategory);
+    }
+}

--- a/src/main/java/gift/service/MemberService.java
+++ b/src/main/java/gift/service/MemberService.java
@@ -1,0 +1,40 @@
+package gift.service;
+
+import gift.dto.request.MemberRequest;
+import gift.entity.Member;
+import gift.exception.EmailDuplicateException;
+import gift.exception.MemberNotFoundException;
+import gift.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public Long register(MemberRequest request) {
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new EmailDuplicateException(request.email());
+        }
+        Member member = new Member(request.email(), request.password());
+        return memberRepository.save(member).getId();
+    }
+
+
+    public Long login(MemberRequest request) {
+        Member registeredMember = memberRepository.findByEmailAndPassword(request.email(), request.password())
+                .orElseThrow(MemberNotFoundException::new);
+        return registeredMember.getId();
+    }
+
+    public Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+}

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -1,0 +1,33 @@
+package gift.service;
+
+import gift.dto.request.OptionRequest;
+import gift.entity.Option;
+import gift.entity.Product;
+import gift.exception.OptionNotFoundException;
+import gift.repository.OptionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OptionService {
+
+    private final OptionRepository optionRepository;
+
+    public OptionService(OptionRepository optionRepository) {
+        this.optionRepository = optionRepository;
+    }
+
+    @Transactional
+    public void subtractOptionQuantity(Long targetOptionId, int subtractQuantity) {
+        Option targetOption = optionRepository.findByIdWithPessimisticWriteLock(targetOptionId)
+                .orElseThrow(() -> new OptionNotFoundException(targetOptionId));
+
+        targetOption.subtract(subtractQuantity);
+    }
+
+    public Option saveOption(Product product, OptionRequest optionRequest) {
+        Option option = new Option(optionRequest.name(), optionRequest.quantity());
+        option.associateWithProduct(product);
+        return optionRepository.save(option);
+    }
+}

--- a/src/main/java/gift/service/OptionService.java
+++ b/src/main/java/gift/service/OptionService.java
@@ -2,7 +2,6 @@ package gift.service;
 
 import gift.dto.request.OptionRequest;
 import gift.entity.Option;
-import gift.entity.Product;
 import gift.exception.OptionNotFoundException;
 import gift.repository.OptionRepository;
 import org.springframework.stereotype.Service;
@@ -25,9 +24,8 @@ public class OptionService {
         targetOption.subtract(subtractQuantity);
     }
 
-    public Option saveOption(Product product, OptionRequest optionRequest) {
+    public Option saveOption(OptionRequest optionRequest) {
         Option option = new Option(optionRequest.name(), optionRequest.quantity());
-        option.associateWithProduct(product);
         return optionRepository.save(option);
     }
 }

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -1,0 +1,101 @@
+package gift.service;
+
+import gift.dto.request.AddProductRequest;
+import gift.dto.request.OptionRequest;
+import gift.dto.request.UpdateProductRequest;
+import gift.dto.response.AddedOptionIdResponse;
+import gift.dto.response.AddedProductIdResponse;
+import gift.dto.response.OptionResponse;
+import gift.dto.response.ProductResponse;
+import gift.entity.Category;
+import gift.entity.Option;
+import gift.entity.Product;
+import gift.exception.ProductNotFoundException;
+import gift.repository.ProductRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class ProductService {
+
+    private final ProductRepository productRepository;
+    private final CategoryService categoryService;
+    private final OptionService optionService;
+
+    public ProductService(ProductRepository productRepository, CategoryService categoryService, OptionService optionService) {
+        this.productRepository = productRepository;
+        this.categoryService = categoryService;
+        this.optionService = optionService;
+    }
+
+    @Transactional
+    public AddedProductIdResponse addProduct(AddProductRequest request) {
+        Category category = categoryService.getCategory(request.categoryId());
+
+        List<Option> options = request.optionRequests()
+                .stream()
+                .map(optionRequest -> new Option(optionRequest.name(), optionRequest.quantity()))
+                .toList();
+
+        Product product = new Product(request.name(), request.price(), request.imageUrl(), category, options);
+
+        Long addedProductId = productRepository.save(product).getId();
+        return new AddedProductIdResponse(addedProductId);
+    }
+
+    public Product getProduct(Long productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(ProductNotFoundException::new);
+    }
+
+    public Page<ProductResponse> getProductResponses(Pageable pageable) {
+        return productRepository.findAll(pageable)
+                .map(ProductResponse::fromProduct);
+    }
+
+    @Transactional
+    public void updateProduct(UpdateProductRequest request) {
+        Product product = productRepository.findById(request.id())
+                .orElseThrow(ProductNotFoundException::new);
+
+        Category category = categoryService.getCategory(request.categoryId());
+
+        product.update(request.name(), request.price(), request.imageUrl(), category);
+    }
+
+    @Transactional
+    public void deleteProduct(Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(ProductNotFoundException::new);
+        productRepository.delete(product);
+    }
+
+    @Transactional
+    public void deleteProducts(List<Long> ids) {
+        productRepository.deleteAllById(ids);
+    }
+
+    public List<OptionResponse> getOptionResponses(Long productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(ProductNotFoundException::new)
+                .getOptions()
+                .stream()
+                .map(OptionResponse::fromOption)
+                .toList();
+    }
+
+    public AddedOptionIdResponse addOptionToProduct(Long productId, OptionRequest optionRequest) {
+        Product product = getProduct(productId);
+
+        product.checkDuplicateOptionName(optionRequest.name());
+        Option savedOption = optionService.saveOption(product, optionRequest);
+
+        product.addOption(savedOption);
+
+        return new AddedOptionIdResponse(savedOption.getId());
+    }
+}

--- a/src/main/java/gift/service/ProductService.java
+++ b/src/main/java/gift/service/ProductService.java
@@ -88,12 +88,11 @@ public class ProductService {
                 .toList();
     }
 
+    @Transactional
     public AddedOptionIdResponse addOptionToProduct(Long productId, OptionRequest optionRequest) {
         Product product = getProduct(productId);
 
-        product.checkDuplicateOptionName(optionRequest.name());
-        Option savedOption = optionService.saveOption(product, optionRequest);
-
+        Option savedOption = optionService.saveOption(optionRequest);
         product.addOption(savedOption);
 
         return new AddedOptionIdResponse(savedOption.getId());

--- a/src/main/java/gift/service/TokenService.java
+++ b/src/main/java/gift/service/TokenService.java
@@ -1,0 +1,50 @@
+package gift.service;
+
+import gift.dto.response.TokenResponse;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Service
+public class TokenService {
+
+    private static final SecretKey KEY = Jwts.SIG.HS256.key().build();
+    private static final int JWT_EXPIRATION_IN_MS = 1000 * 60 * 60 * 2;
+
+    public TokenResponse generateToken(Long registeredMemberId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + JWT_EXPIRATION_IN_MS);
+        String tokenValue = Jwts.builder()
+                .claim("memberId", registeredMemberId)
+                .expiration(expiryDate)
+                .signWith(KEY)
+                .compact();
+        return new TokenResponse(tokenValue);
+    }
+
+    public Long getMemberId(String tokenValue) {
+        String resultOfString = Jwts.parser()
+                .verifyWith(KEY)
+                .build()
+                .parseSignedClaims(tokenValue)
+                .getPayload()
+                .get("memberId")
+                .toString();
+        return Long.parseLong(resultOfString);
+    }
+
+    public boolean isValidateToken(String tokenValue) {
+        try {
+            Jwts.parser()
+                    .verifyWith(KEY)
+                    .build()
+                    .parseSignedClaims(tokenValue);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -1,0 +1,70 @@
+package gift.service;
+
+import gift.dto.request.WishRequest;
+import gift.dto.response.WishProductResponse;
+import gift.entity.Member;
+import gift.entity.Product;
+import gift.entity.Wish;
+import gift.exception.WishAlreadyExistsException;
+import gift.exception.WishNotFoundException;
+import gift.repository.WishRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class WishService {
+
+    private final WishRepository wishRepository;
+    private final ProductService productService;
+    private final MemberService memberService;
+
+    public WishService(WishRepository wishRepository, ProductService productService, MemberService memberService) {
+        this.wishRepository = wishRepository;
+        this.productService = productService;
+        this.memberService = memberService;
+    }
+
+    @Transactional
+    public void addProductToWish(Long memberId, WishRequest request) {
+        Member member = memberService.getMember(memberId);
+        Product product = productService.getProduct(request.productId());
+
+        if (wishRepository.existsByMemberAndProduct(member, product)) {
+            throw new WishAlreadyExistsException(request.productId());
+        }
+
+        Wish wish = new Wish(member, request.quantity(), product);
+        wishRepository.save(wish);
+    }
+
+    public Page<WishProductResponse> getWishProductResponses(Long memberId, Pageable pageable) {
+        Member member = memberService.getMember(memberId);
+
+        return wishRepository.findAllByMember(member, pageable)
+                .map(WishProductResponse::fromWish);
+    }
+
+    @Transactional
+    public void updateWishProductQuantity(Long memberId, WishRequest request) {
+        Member member = memberService.getMember(memberId);
+        Product product = productService.getProduct(request.productId());
+
+        Wish wish = wishRepository.findByMemberAndProduct(member, product)
+                .orElseThrow(WishNotFoundException::new);
+
+        wish.updateQuantity(request.quantity());
+    }
+
+    @Transactional
+    public void deleteProductInWish(Long memberId, Long productId) {
+        Member member = memberService.getMember(memberId);
+        Product product = productService.getProduct(productId);
+
+        Wish wish = wishRepository.findByMemberAndProduct(member, product)
+                .orElseThrow(WishNotFoundException::new);
+
+        wishRepository.delete(wish);
+    }
+}

--- a/src/main/java/gift/validation/ContainsOnlyAllowedSpecialCharacter.java
+++ b/src/main/java/gift/validation/ContainsOnlyAllowedSpecialCharacter.java
@@ -1,0 +1,22 @@
+package gift.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ContainsOnlyAllowedSpecialCharacterValidator.class)
+public @interface ContainsOnlyAllowedSpecialCharacter {
+
+    String message() default "{gift.validation.ContainsOnlyAllowedSpecialCharacter.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/gift/validation/ContainsOnlyAllowedSpecialCharacterValidator.java
+++ b/src/main/java/gift/validation/ContainsOnlyAllowedSpecialCharacterValidator.java
@@ -1,0 +1,20 @@
+package gift.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ContainsOnlyAllowedSpecialCharacterValidator implements ConstraintValidator<ContainsOnlyAllowedSpecialCharacter, String> {
+
+    private static final Set<Character> ALLOWED_SPECIAL_CHARACTERS = new HashSet<>(Arrays.asList('(', ')', '[', ']', '+', '-', '&', '/', '_', ' '));
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value.chars()
+                .allMatch(c -> Character.isLetterOrDigit(c) || ALLOWED_SPECIAL_CHARACTERS.contains((char) c));
+    }
+
+}

--- a/src/main/java/gift/validation/NotContainsKakao.java
+++ b/src/main/java/gift/validation/NotContainsKakao.java
@@ -1,0 +1,22 @@
+package gift.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = NotContainsKakaoValidator.class)
+public @interface NotContainsKakao {
+
+    String message() default "{gift.validation.NotContainsKakao.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/gift/validation/NotContainsKakaoValidator.java
+++ b/src/main/java/gift/validation/NotContainsKakaoValidator.java
@@ -1,0 +1,13 @@
+package gift.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NotContainsKakaoValidator implements ConstraintValidator<NotContainsKakao, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return !value.contains("카카오");
+    }
+
+}

--- a/src/main/java/gift/validation/UniqueOptionNames.java
+++ b/src/main/java/gift/validation/UniqueOptionNames.java
@@ -1,0 +1,21 @@
+package gift.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = UniqueOptionNamesValidator.class)
+public @interface UniqueOptionNames {
+
+    String message() default "Option names must unique.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/gift/validation/UniqueOptionNamesValidator.java
+++ b/src/main/java/gift/validation/UniqueOptionNamesValidator.java
@@ -1,0 +1,21 @@
+package gift.validation;
+
+import gift.dto.request.OptionRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class UniqueOptionNamesValidator implements ConstraintValidator<UniqueOptionNames, List<OptionRequest>> {
+
+    @Override
+    public boolean isValid(List<OptionRequest> value, ConstraintValidatorContext context) {
+        Set<String> uniqueNames = new HashSet<>();
+
+        return value.stream()
+                .map(OptionRequest::name)
+                .allMatch(name -> uniqueNames.add(name));
+    }
+}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,1 @@
+#active profiel

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=spring-gift
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.username=sa
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true
+logging.level.org.hibernate.orm.jdbc.bind=TRACE

--- a/src/main/resources/static/add.css
+++ b/src/main/resources/static/add.css
@@ -1,0 +1,57 @@
+/* style.css */
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f4f9;
+    margin: 0;
+    padding: 0;
+}
+
+.container {
+    width: 80%;
+    margin: 20px auto;
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+    font-size: 24px;
+    margin-bottom: 20px;
+}
+
+form {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+label {
+    display: block;
+    margin: 10px 0 5px;
+    font-weight: bold;
+}
+
+input[type="text"] {
+    width: calc(100% - 22px);
+    padding: 10px;
+    margin-bottom: 20px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+button {
+    background-color: #28a745;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+button:hover {
+    background-color: #218838;
+}

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -1,0 +1,174 @@
+/*body {*/
+/*    height: 100%;*/
+/*    margin: 0;*/
+/*    display: flex;*/
+/*    justify-content: center;*/
+/*    align-items: center;*/
+/*}*/
+
+/*.container {*/
+/*    text-align: center;*/
+/*}*/
+/* style.css */
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f4f9;
+    margin: 0;
+    padding: 0;
+}
+
+.container {
+    width: 80%;
+    margin: 20px auto;
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+    font-size: 24px;
+    margin-bottom: 20px;
+}
+
+
+#addButton {
+    background-color: forestgreen;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 19px;
+}
+
+#addButton:hover {
+    background-color: darkgreen;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 19px;
+}
+
+#selectDeleteButton {
+    background-color: darkred;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 19px;
+}
+
+#selectDeleteButton:hover {
+    background-color: orangered;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 19px;
+}
+
+#deleteButton {
+    background-color: darkred;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 19px;
+}
+
+#deleteButton:hover {
+    background-color: orangered;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 19px;
+}
+
+#editButton {
+    background-color: blue;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 19px;
+}
+
+#editButton:hover {
+    background-color: cornflowerblue;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 19px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+thead {
+    background-color: #343a40;
+    color: #fff;
+}
+
+thead th {
+    padding: 10px;
+    text-align: center;
+}
+
+tbody tr {
+    border-bottom: 1px solid #ddd;
+}
+
+tbody tr:nth-child(even) {
+    background-color: #f9f9f9;
+}
+
+tbody td {
+    padding: 10px;
+    text-align: center; /* Center-align body cells */
+
+}
+
+img {
+    border-radius: 4px;
+}
+
+input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+}
+
+
+/*a{*/
+/*    background-color: darkgreen;*/
+/*    border: none;*/
+/*    color: white;*/
+/*    text-decoration-line: none;*/
+/*    padding: 5px 10px;*/
+/*    border-radius: 3px;*/
+/*    cursor: pointer;*/
+/*    margin-right: 5px;*/
+/*    text-decoration: none;*/
+
+/*}*/
+/*a:hover{*/
+/*    background-color: forestgreen;*/
+
+/*}*/
+
+button[type="submit"]:hover {
+    background-color: #0056b3;
+}

--- a/src/main/resources/templates/version-SSR/add-error.html
+++ b/src/main/resources/templates/version-SSR/add-error.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>상품 추가 실패</title>
+    <link rel="stylesheet" th:href="@{/add.css}"/>
+</head>
+<body>
+
+<form class="container">
+    <h2>이미 존재하는 상품 id입니다.</h2>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/version-SSR/add-form.html
+++ b/src/main/resources/templates/version-SSR/add-form.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>상품 추가</title>
+    <link rel="stylesheet" th:href="@{/add.css}"/>
+</head>
+<body>
+
+<form class="container" method="post" th:action="@{/add}" th:object="${addProductRequest}">
+    <h1>상품 추가</h1>
+    <label for="category">Category:</label>
+    <select id="category" th:field="*{categoryId}">
+        <option th:each="category : ${categories}" th:text="${category.name}" th:value="${category.id}"></option>
+    </select>
+
+    <label for="name">Name:</label>
+    <input id="name" required th:field="*{name}" type="text"/><br/>
+
+    <label for="price">Price:</label>
+    <input id="price" required th:field="*{price}" type="text"/><br/>
+
+    <label for="imageUrl">Image URL:</label>
+    <input id="imageUrl" required th:field="*{imageUrl}" type="text"/><br/>
+
+    <button type="submit">추가</button>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/version-SSR/edit-error.html
+++ b/src/main/resources/templates/version-SSR/edit-error.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>상품 추가 실패</title>
+    <link rel="stylesheet" th:href="@{/add.css}"/>
+</head>
+<body>
+
+<form class="container">
+    <h2>존재하지 않는 상품 id입니다.</h2>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/version-SSR/edit-form.html
+++ b/src/main/resources/templates/version-SSR/edit-form.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+          name="viewport">
+    <meta content="ie=edge" http-equiv="X-UA-Compatible">
+    <title>상품 수정</title>
+    <link rel="stylesheet" th:href="@{/add.css}"/>
+
+</head>
+<body>
+<form class="container" method="post" th:action="@{/edit}" th:object="${updateProductRequest}">
+    <h1>상품 수정</h1>
+    <!-- ID는 readonly 속성 수정 불가하게 -->
+    <label for="id">ID:</label>
+    <input id="id" readonly th:field="*{id}" type="text"/><br/>
+
+    <!-- 카테고리  -->
+    <label for="category">Category:</label>
+    <select id="category" th:field="*{categoryId}">
+        <option th:each="category : ${categories}" th:selected="${category.id == updateProductRequest.categoryId}"
+                th:text="${category.name}" th:value="${category.id}"></option>
+    </select><br/><br/>
+
+    <!--그 외 값들-->
+    <label style="color: #888">Current Name: <span style="color: #888;"
+                                                   th:text="${updateProductRequest.name}"></span></label>
+    <label for="name">New Name:</label>
+    <input id="name" required th:field="*{name}" type="text"/><br/>
+
+    <label style="color: #888">Current Price: <span style="color: #888;" th:text="${updateProductRequest.price}"></span></label>
+    <label for="price">New Price:</label>
+    <input id="price" required th:field="*{price}" type="text"/><br/>
+
+    <label style="color: #888">Current Image URL: <span th:text="${updateProductRequest.imageUrl}"></span></label>
+    <label for="imageUrl">New Image URL:</label>
+    <input id="imageUrl" required th:field="*{imageUrl}" type="text"/><br/>
+
+    <button type="submit">수정</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/version-SSR/index.html
+++ b/src/main/resources/templates/version-SSR/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>상품 관리</title>
+    <link rel="stylesheet" th:href="@{/style.css}"/>
+
+    <script>
+        function submitForm(id) {
+            // 직접적으로 폼을 서밋하는 방식으로 수정
+            document.getElementById('deleteFormInputId').value = id;//
+            document.getElementById('deleteForm').submit();
+        }
+
+        function checkIfAnyCheckboxChecked() {
+            var checkboxes = document.getElementsByName('productIds');
+            for (var i = 0; i < checkboxes.length; i++) {
+                if (checkboxes[i].checked) {
+                    return true; // 하나 이상의 체크박스가 체크되어 있음
+                }
+            }
+            return false; // 체크된 체크박스가 없음
+        }
+
+        function submitSelectDelete() {
+            if (!checkIfAnyCheckboxChecked()) {
+                // event.preventDefault(); // 체크된 체크박스가 없으면 기본 동작을 막음
+                alert('삭제할 상품을 선택해 주세요.'); // 사용자에게 알림을 줄 수도 있음
+            } else {
+                document.getElementById('all').submit();
+            }
+        }
+
+        document.getElementById('selectDeleteButton').addEventListener('click', function (event) {
+            if (!checkIfAnyCheckboxChecked()) {
+                event.preventDefault(); // 체크된 체크박스가 없으면 기본 동작을 막음
+                alert('삭제할 상품을 선택해 주세요.'); // 사용자에게 알림을 줄 수도 있음
+            }
+        });
+    </script>
+</head>
+<body>
+<div class="container">
+    <a th:href="@{/add}">
+        <button id="addButton">상품 추가</button>
+    </a>
+    <button form="all" id="selectDeleteButton" onclick="submitSelectDelete()" type="button">선택된 상품들 일괄 삭제</button>
+    <form id="all" method="post" th:action="@{/deleteSelected}">
+
+        <div>
+            <table>
+                <thead>
+                <tr>
+                    <th>선택</th>
+                    <th>Actions</th>
+                    <th>ID</th>
+                    <th>Category</th>
+                    <th>NAME</th>
+                    <th>PRICE</th>
+                    <th>IMAGE</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="product : ${products}">
+                    <td>
+                        <input name="productIds" th:value="${product.id}" type="checkbox"/>
+                    </td>
+                    <td>
+                        <!-- 삭제 폼 -->
+                        <button id="deleteButton" th:onclick="'submitForm(\'' + ${product.id} + '\')'" type="button">
+                            삭제
+                        </button>
+
+                        <a th:href="@{/edit/{id}(id=${product.id})}">
+                            <button id="editButton" type="button">수정</button>
+                        </a>
+                    </td>
+                    <td th:text="${product.id}">id</td>
+                    <td th:text="${product.categoryName}">category</td>
+                    <td th:text="${product.name}">name</td>
+                    <td th:text="${product.price}">price</td>
+                    <td>
+                        <img alt="Product Image" height="200" th:src="${product.imageUrl}" width="200"/>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </form>
+
+</div>
+
+<!-- 단일 상품 삭제 폼 -->
+<form id="deleteForm" method="post" style="display:none;" th:action="@{/delete}">
+    <input \ id="deleteFormInputId" name="productId" type="hidden">  <!--name은 모델의 이름 -->
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/version-SSR/product-error.html
+++ b/src/main/resources/templates/version-SSR/product-error.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>상품 정보 오류</title>
+    <link rel="stylesheet" th:href="@{/add.css}"/>
+</head>
+<body>
+<div class="container">
+    <div th:each="reason : ${invalidReasons}">
+        <h3 th:text=" ${reason}"></h3>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/gift/concurrency/OptionQuantityTest.java
+++ b/src/test/java/gift/concurrency/OptionQuantityTest.java
@@ -1,0 +1,100 @@
+package gift.concurrency;
+
+import gift.entity.Option;
+import gift.exception.InsufficientOptionQuantityException;
+import gift.repository.OptionRepository;
+import gift.service.OptionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@DisplayName("옵션 수량 감소 동시성 테스트")
+public class OptionQuantityTest {
+
+    @Autowired
+    private OptionService optionService;
+    @Autowired
+    private OptionRepository optionRepository;
+
+
+    @Test
+    @DisplayName("100개 스레드가 비동기식으로 차감 시도")
+    void whenSubtractTwoThread0() throws InterruptedException {
+        //Given
+        Long testOptionId = optionRepository.save(new Option("optionName", 1000)).getId();
+        int subtractQuantity = 10;
+        int threadCount = 100;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        //When
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() ->
+                    optionService.subtractOptionQuantity(testOptionId, subtractQuantity)
+            );
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+        //Then
+        Option updatedOption = optionRepository.findById(testOptionId).orElseThrow();
+        assertEquals(0, updatedOption.getQuantity());
+    }
+
+    @Test
+    @DisplayName("100개 스레드가 비동기식으로 차감 시도 - 0개가 되면 예외처리 하는가")
+    void whenSubtractTwoThread1() throws InterruptedException {
+        //Given
+        Long testOptionId = optionRepository.save(new Option("optionName", 1000)).getId();
+        int subtractQuantity = 100;
+        int threadCount = 100;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        List<Future<?>> futures = new ArrayList<>();
+        List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+
+        //When
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executorService.submit(() -> {
+                try {
+                    optionService.subtractOptionQuantity(testOptionId, subtractQuantity);
+                } catch (Exception e) {
+                    exceptions.add(e);
+                }
+            }));
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+        for (Future<?> future : futures) {
+            try {
+                future.get();
+            } catch (Exception e) {
+                exceptions.add(e);
+            }
+        }
+
+        //Then
+        Option updatedOption = optionRepository.findById(testOptionId).orElseThrow();
+
+        assertThat(updatedOption.getQuantity()).isEqualTo(0);
+        assertThat(exceptions).hasSize(90)
+                .first()
+                .isInstanceOf(InsufficientOptionQuantityException.class);
+    }
+}

--- a/src/test/java/gift/controller/api/CategoryControllerTest.java
+++ b/src/test/java/gift/controller/api/CategoryControllerTest.java
@@ -1,0 +1,80 @@
+package gift.controller.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.dto.request.AddCategoryRequest;
+import gift.dto.response.CategoryIdResponse;
+import gift.dto.response.CategoryResponse;
+import gift.service.CategoryService;
+import gift.service.TokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CategoryController.class)
+@DisplayName("카테고리 컨트롤러 단위테스트")
+class CategoryControllerTest {
+
+    private static final String URL = "/api/categories";
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private CategoryService categoryService;
+    @MockBean
+    private TokenService tokenService;
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    @DisplayName("카테고리 추가")
+    void addCategory() throws Exception {
+        //Given
+        AddCategoryRequest addCategoryRequest = new AddCategoryRequest("교환권", "색", "이미지주소", "설명");
+        CategoryIdResponse addedCategoryIdResponse = new CategoryIdResponse(1L);
+
+        //When
+        when(categoryService.addCategory(addCategoryRequest)).thenReturn(addedCategoryIdResponse);
+
+        //Then
+        mockMvc.perform(MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(addCategoryRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("id").value(1L)
+                );
+    }
+
+    @Test
+    @DisplayName("모든 카테고리 조회")
+    void getCategories() throws Exception {
+        //Given
+        List<CategoryResponse> categoryResponses = new ArrayList<>();
+        categoryResponses.add(new CategoryResponse(1L, "교환권", "색", "이미지주소", "설명"));
+        categoryResponses.add(new CategoryResponse(2L, "백화점", "색", "이미지주소", "설명"));
+
+        //When
+        when(categoryService.getAllCategoryResponses()).thenReturn(categoryResponses);
+
+        //Then
+        mockMvc.perform(MockMvcRequestBuilders.get(URL))
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("[0].id").value(1L),
+                        jsonPath("[1].id").value(2L)
+                );
+    }
+}

--- a/src/test/java/gift/controller/api/MemberControllerTest.java
+++ b/src/test/java/gift/controller/api/MemberControllerTest.java
@@ -1,0 +1,80 @@
+package gift.controller.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.dto.request.MemberRequest;
+import gift.dto.response.TokenResponse;
+import gift.service.MemberService;
+import gift.service.TokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = MemberController.class)
+@DisplayName("멤버 컨트롤러 단위테스트")
+class MemberControllerTest {
+
+    private static final String REGISTER_URL = "/members/register";
+    private static final String LOGIN_URL = "/members/login";
+    @MockBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private MemberService memberService;
+    @MockBean
+    private TokenService tokenService;
+
+    @Test
+    @DisplayName("회원가입")
+    void registerMember() throws Exception {
+        //Given
+        MemberRequest registerRequest = new MemberRequest("member1@gmail.com", "1234");
+
+        when(memberService.register(registerRequest)).thenReturn(1L);
+        when(tokenService.generateToken(1L)).thenReturn(new TokenResponse("JSH"));
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post(REGISTER_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(registerRequest)))
+                //Then
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("token").exists()
+                );
+    }
+
+    @Test
+    @DisplayName("로그인")
+    void loginMember() throws Exception {
+        //Given
+        MemberRequest loginRequest = new MemberRequest("member1@gmail.com", "1234");
+        when(memberService.login(loginRequest)).thenReturn(1L);
+        when(tokenService.generateToken(1L)).thenReturn(new TokenResponse("secret"));
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post(LOGIN_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                //Then
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("token").exists()
+                );
+    }
+}

--- a/src/test/java/gift/controller/api/ProductControllerTest.java
+++ b/src/test/java/gift/controller/api/ProductControllerTest.java
@@ -1,0 +1,169 @@
+package gift.controller.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.dto.request.AddProductRequest;
+import gift.dto.request.OptionRequest;
+import gift.dto.request.UpdateProductRequest;
+import gift.dto.response.AddedOptionIdResponse;
+import gift.dto.response.AddedProductIdResponse;
+import gift.dto.response.OptionResponse;
+import gift.dto.response.ProductResponse;
+import gift.service.ProductService;
+import gift.service.TokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ProductController.class)
+@DisplayName("상품 컨트롤러 단위테스트")
+class ProductControllerTest {
+
+    private static final String URL = "/api/products";
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private ProductService productService;
+    @MockBean
+    private TokenService tokenService;
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("상품 조회")
+    void getProducts() throws Exception {
+        // Given
+        List<ProductResponse> products = List.of(
+                new ProductResponse(1L, "Product 1", 100, "img", "Cloth"),
+                new ProductResponse(2L, "Product 2", 200, "img", "Food")
+        );
+        Page<ProductResponse> page = new PageImpl<>(products);
+        when(productService.getProductResponses(any(Pageable.class))).thenReturn(page);
+
+        // When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get(URL)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.content").exists(),
+                        jsonPath("$.content[1].name").value("Product 2")
+                );
+    }
+
+
+    @Test
+    @DisplayName("상품 추가")
+    void addProduct() throws Exception {
+        // Given
+        AddProductRequest addProductRequest = new AddProductRequest("Product1", 110, "img", 1L, List.of(new OptionRequest("option1", 100)));
+        AddedProductIdResponse addedProductIdResponse = new AddedProductIdResponse(1L);
+
+        when(productService.addProduct(addProductRequest)).thenReturn(addedProductIdResponse);
+
+        // When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(addProductRequest)))
+                //Then
+                .andExpectAll(
+                        status().isCreated(),
+                        jsonPath("$.id").value(1L)
+                );
+    }
+
+
+    @Test
+    @DisplayName("상품 수정")
+    void updateProduct() throws Exception {
+        // Given
+        UpdateProductRequest updateProductRequest = new UpdateProductRequest(1L, "changeProduct1", 110, "img", 1L);
+
+        // When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .put(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateProductRequest)))
+                //Then
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("상품 삭제")
+    void deleteProduct() throws Exception {
+        // Given
+        Long deleteTargetId = 1L;
+
+        // When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .delete(URL + "/{id}", deleteTargetId))
+                //Then
+                .andExpect(status().isOk());
+        verify(productService, times(1)).deleteProduct(deleteTargetId);
+    }
+
+    @Test
+    @DisplayName("상품 옵션 조회")
+    void getOptionResponses() throws Exception {
+        //Given
+        Long productId = 1L;
+        List<OptionResponse> optionResponses = List.of(
+                new OptionResponse(1L, "옵션1", 100),
+                new OptionResponse(2L, "옵션1", 100)
+        );
+
+        when(productService.getOptionResponses(productId)).thenReturn(optionResponses);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get(URL + "/1/options"))
+                //Then
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("[0].name").value("옵션1"),
+                        jsonPath("[0].id").value(1),
+                        jsonPath("[1].name").value("옵션1"),
+                        jsonPath("[1].id").value(2)
+                );
+    }
+
+    @Test
+    @DisplayName("상품 옵션 조회")
+    void addOptionToProduct() throws Exception {
+        //Given
+        Long productId = 1L;
+        OptionRequest optionRequest = new OptionRequest("옵션1", 9900);
+        AddedOptionIdResponse addedOptionIdResponse = new AddedOptionIdResponse(1L);
+
+        when(productService.addOptionToProduct(productId, optionRequest)).thenReturn(addedOptionIdResponse);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post(URL + "/1/options")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(optionRequest)))
+                //Then
+                .andExpectAll(
+                        status().isCreated(),
+                        jsonPath("optionId").value(1)
+                );
+    }
+}

--- a/src/test/java/gift/controller/api/WishControllerTest.java
+++ b/src/test/java/gift/controller/api/WishControllerTest.java
@@ -1,0 +1,119 @@
+package gift.controller.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.dto.request.WishRequest;
+import gift.dto.response.WishProductResponse;
+import gift.interceptor.AuthInterceptor;
+import gift.service.TokenService;
+import gift.service.WishService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = WishController.class)
+@DisplayName("위시 컨트롤러 단위테스트")
+class WishControllerTest {
+
+    private static final String URL = "/api/wishlist";
+    @MockBean
+    private TokenService tokenService;
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+    @MockBean
+    private AuthInterceptor authInterceptor;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private WishService wishService;
+
+    @Test
+    @DisplayName("위시리스트 상품 추가")
+    void addProductToWishList() throws Exception {
+        //Given
+        when(authInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+        WishRequest request = new WishRequest(1L, 100);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders.post(URL)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer validTokenValue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                //Then
+                .andExpect(
+                        status().isCreated()
+                );
+    }
+
+    @Test
+    @DisplayName("위시리스트 상품 조회")
+    void getWishProducts() throws Exception {
+        //Given
+        when(authInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+        Page<WishProductResponse> page = new PageImpl<>(List.of(
+                new WishProductResponse(1L, "product1", 100, "img", 1000),
+                new WishProductResponse(2L, "product2", 400, "img", 2000)
+        ));
+        when(wishService.getWishProductResponses(any(), any())).thenReturn(page);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get(URL))
+                //Then
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.content[0].productName").value("product1"),
+                        jsonPath("$.content[1].productName").value("product2")
+                );
+    }
+
+    @Test
+    @DisplayName("위시리스트 상품 수정")
+    void updateWishProductAmount() throws Exception {
+        //Given
+        when(authInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+        WishRequest updateRequest = new WishRequest(1L, 1000);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .put(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                //Then
+                .andExpect(
+                        status().isOk()
+                );
+    }
+
+    @Test
+    @DisplayName("위시리스트 상품 삭제")
+    void deleteWishProduct() throws Exception {
+        //Given
+        when(authInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .delete(URL + "/1"))
+                //Then
+                .andExpect(
+                        status().isOk()
+                );
+    }
+}

--- a/src/test/java/gift/dto/request/AddProductRequestTest.java
+++ b/src/test/java/gift/dto/request/AddProductRequestTest.java
@@ -1,0 +1,112 @@
+package gift.dto.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("상품 추가 요청 DTO 테스트")
+class AddProductRequestTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    public void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("옵션 이름 중복")
+    void testValidAddProductRequest1() {
+        //Given
+        AddProductRequest request = new AddProductRequest(
+                "ValidName",
+                1000,
+                "http://example.com/image.jpg",
+                1L,
+                List.of(new OptionRequest("Option1", 101),
+                        new OptionRequest("Option1", 1))
+        );
+
+        //When
+        Set<ConstraintViolation<AddProductRequest>> violations = validator.validate(request);
+
+        //Then
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("상품의 옵션 이름은 중복될 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("옵션 0개")
+    void testValidAddProductRequest2() {
+        //Given
+        AddProductRequest request = new AddProductRequest(
+                "ValidName",
+                1000,
+                "http://example.com/image.jpg",
+                1L,
+                new ArrayList<>()
+        );
+
+        //When
+        Set<ConstraintViolation<AddProductRequest>> violations = validator.validate(request);
+
+        //Then
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("상품에는 하나 이상의 옵션이 있어야합니다.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a", "15자____________", "    햇반      ", "[단독] 고급 지갑", "커피&우유", "1+1 제품", "/바로/구매___", "-_- 안사면 후회"})
+    @DisplayName("유효한 상품 이름")
+    void testValidAddProductRequest3(String name) {
+        //Given
+        AddProductRequest request = new AddProductRequest(
+                name,
+                1000,
+                "http://example.com/image.jpg",
+                1L,
+                List.of(new OptionRequest("Option1", 101),
+                        new OptionRequest("Option2", 1))
+        );
+
+        //When
+        Set<ConstraintViolation<AddProductRequest>> violations = validator.validate(request);
+
+        //Then
+        assertThat(violations.isEmpty()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"!!!", "저렴한 우유!!", "@멘션", "#더샵", "진짜~~~~", "카카오톡", "카카오 우유", "카카오카카오", "16자_____________", "15자 넘는 공백              포함"})
+    @DisplayName("비유효한 상품 이름")
+    void testValidAddProductRequest4(String name) {
+        //Given
+        AddProductRequest request = new AddProductRequest(
+                name,
+                1000,
+                "http://example.com/image.jpg",
+                1L,
+                List.of(new OptionRequest("Option1", 101),
+                        new OptionRequest("Option2", 1))
+        );
+
+        //When
+        Set<ConstraintViolation<AddProductRequest>> violations = validator.validate(request);
+
+        //Then
+        assertThat(violations.isEmpty()).isFalse();
+    }
+}

--- a/src/test/java/gift/e2e/MemberTest.java
+++ b/src/test/java/gift/e2e/MemberTest.java
@@ -1,0 +1,130 @@
+package gift.e2e;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.dto.request.MemberRequest;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("멤버 회원가입, 로그인 기능 테스트")
+class MemberTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @Order(1)
+    @DisplayName("회원가입")
+    void registerMember() throws Exception {
+        //Given
+        MemberRequest registerRequest = new MemberRequest("member1@gmail.com", "1234");
+        String requestJson = objectMapper.writeValueAsString(registerRequest);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/members/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                //Then
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("token").exists()
+                );
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("로그인 성공")
+    void loginMember() throws Exception {
+        //Given
+        MemberRequest request = new MemberRequest("member1@gmail.com", "1234");
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                //Then
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("token").exists()
+                );
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("로그인 실패 - 틀린 이메일")
+    void loginMemberFail() throws Exception {
+        //Given
+        MemberRequest request = new MemberRequest("noResgietEmail@naver.com", "1234");
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                //Then
+                .andExpectAll(
+                        status().isBadRequest(),
+                        content().contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                );
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("로그인 실패 - 비번 틀림")
+    void loginFail() throws Exception {
+        //Given
+        MemberRequest wrongInfoRequest = new MemberRequest("member1@gmail.com", "999999");
+        String requestJson = objectMapper.writeValueAsString(wrongInfoRequest);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                //Then
+                .andExpectAll(
+                        status().isBadRequest(),
+                        content().contentType(MediaType.APPLICATION_PROBLEM_JSON),
+                        jsonPath("title").value("Member not found")
+                );
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("사용중인 이메일로 회원가입")
+    void duplicatedEmailRegister() throws Exception {
+        //Given
+        MemberRequest duplicatedEmailRegisterRequest = new MemberRequest("member1@gmail.com", "1234");
+        String requestJson = objectMapper.writeValueAsString(duplicatedEmailRegisterRequest);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/members/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                //Then
+                .andExpectAll(
+                        status().isConflict(),
+                        content().contentType(MediaType.APPLICATION_PROBLEM_JSON),
+                        jsonPath("title").value("member1@gmail.com already in use")
+                );
+    }
+}

--- a/src/test/java/gift/e2e/ProductTest.java
+++ b/src/test/java/gift/e2e/ProductTest.java
@@ -1,0 +1,124 @@
+package gift.e2e;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.dto.request.AddCategoryRequest;
+import gift.dto.request.AddProductRequest;
+import gift.dto.request.OptionRequest;
+import gift.dto.request.UpdateProductRequest;
+import gift.service.CategoryService;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("상품/옵션 조회,추가,수정 기능 테스트")
+public class ProductTest {
+
+    private static Long savedProductId;
+    private static Long categoryId;
+    private final String URL = "/api/products";
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private CategoryService categoryService;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @Order(1)
+    @DisplayName("상품 추가")
+    void productAdd() throws Exception {
+        //Given
+        categoryId = categoryService.addCategory(new AddCategoryRequest("카테고리", "color", "imageUrl", "des")).id();
+        AddProductRequest request = new AddProductRequest("상품이름", 100, "url", categoryId, List.of(new OptionRequest("option1", 100)));
+
+        //When
+        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders.post(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                //Then
+                .andExpectAll(
+                        status().isCreated(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("id").exists()
+                ).andReturn();
+        String contentAsString = mvcResult.getResponse().getContentAsString();
+        String substring = contentAsString.substring(1, contentAsString.length() - 1);
+        savedProductId = Long.parseLong(substring.split(":")[1]);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("상품 수정")
+    void update() throws Exception {
+        //Given
+        UpdateProductRequest request = new UpdateProductRequest(savedProductId, "UPDATENAME", 100, "url", categoryId);
+
+        //When
+        mockMvc.perform(MockMvcRequestBuilders.put(URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                //Then
+                .andExpectAll(
+                        status().isOk()
+                );
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("상품들 조회")
+    void getProducts() throws Exception {
+        //When
+        mockMvc.perform(MockMvcRequestBuilders.get(URL))
+                //Then
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON)
+                );
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("상품 옵션 추가")
+    void optionAdd() throws Exception {
+        //Given
+        OptionRequest request = new OptionRequest("New Option", 999);
+        //When
+        mockMvc.perform(MockMvcRequestBuilders.post(URL + "/" + savedProductId + "/options")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                //Then
+                .andExpectAll(
+                        status().isCreated(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("optionId").exists()
+                );
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("상품 옵션 조회")
+    void optionGet() throws Exception {
+        //When
+        mockMvc.perform(MockMvcRequestBuilders.get(URL + "/" + savedProductId + "/options"))
+                //Then
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("[1].quantity").value(999)
+                );
+    }
+}

--- a/src/test/java/gift/entity/OptionTest.java
+++ b/src/test/java/gift/entity/OptionTest.java
@@ -1,0 +1,70 @@
+package gift.entity;
+
+import gift.exception.InsufficientOptionQuantityException;
+import gift.repository.OptionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@DisplayName("옵션 엔티티 테스트")
+class OptionTest {
+
+    @Autowired
+    OptionRepository optionRepository;
+
+    @Test
+    @DisplayName("Name Null")
+    void nameNull() {
+        Option option = new Option(null, 100);
+
+        assertThatThrownBy(() -> optionRepository.save(option))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("Quantity Null")
+    void quantityNull() {
+        Option option = new Option("name", null);
+
+        assertThatThrownBy(() -> optionRepository.save(option))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("정상적으로")
+    void success() {
+        Option option = new Option("name", 100);
+
+        assertThat(optionRepository.save(option).getId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("옵션 수량 차감 - 성공")
+    void subtractSuccess() {
+        //Given
+        Option option = new Option("name", 100);
+
+        //When
+        option.subtract(50);
+
+        //Then
+        assertThat(option.getQuantity()).isEqualTo(50);
+    }
+
+    @Test
+    @DisplayName("옵션 수량 차감 - 차감 수량이 더 커서 실패")
+    void subtractFail() {
+        //Given
+        Option option = new Option("name", 100);
+
+        //When Then
+        assertThatThrownBy(() -> option.subtract(101))
+                .isInstanceOf(InsufficientOptionQuantityException.class);
+    }
+}

--- a/src/test/java/gift/entity/ProductTest.java
+++ b/src/test/java/gift/entity/ProductTest.java
@@ -1,0 +1,43 @@
+package gift.entity;
+
+import gift.exception.OptionDuplicateException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@DisplayName("상품 엔티티 테스트")
+class ProductTest {
+
+    @Test
+    @DisplayName("옵션 이름 중복 검사 - 같은 이름이 존재하여 실패")
+    void checkDuplicateOptionNameFail() {
+        //Given
+        Product product = new Product("name", 100, "url", new Category("Food", "t", "t", "t"), List.of(new Option("option", 100)));
+        String newOptionName = "option";
+
+        //When Then
+        assertThatThrownBy(() -> product.checkDuplicateOptionName(newOptionName))
+                .isInstanceOf(OptionDuplicateException.class);
+    }
+
+    @Test
+    @DisplayName("옵션 이름 중복 검사 - 성공")
+    void checkDuplicateOptionNameSuccess() {
+        //Given
+        Option option = new Option("option", 100);
+        Product product = new Product("name", 100, "url", new Category("Food", "t", "t", "t"), List.of(option));
+        option.associateWithProduct(product);
+
+        String newOptionName = "otherOptionName";
+
+        //When
+        product.checkDuplicateOptionName(newOptionName);
+
+        //Then
+        assertDoesNotThrow(() -> product.checkDuplicateOptionName(newOptionName));
+    }
+}

--- a/src/test/java/gift/repository/CategoryRepositoryTest.java
+++ b/src/test/java/gift/repository/CategoryRepositoryTest.java
@@ -1,0 +1,84 @@
+package gift.repository;
+
+import gift.entity.Category;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@DisplayName("카테고리 레포지토리 단위테스트")
+class CategoryRepositoryTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Test
+    @DisplayName("카테고리 이름 중복 확인")
+    void existsByName() {
+        //Given
+        Category category = new Category("test", "test", "test", "test");
+        categoryRepository.save(category);
+
+        //When
+        boolean resultBoolean = categoryRepository.existsByName("test");
+
+        //Then
+        assertThat(resultBoolean).isTrue();
+    }
+
+    @Nested
+    @DisplayName("카테고리 엔티티 테스트")
+    class EntityTest {
+        @Test
+        @DisplayName("Name Null")
+        void nameNull() {
+            Category category = new Category(null, "color", "imageUrl", "description");
+
+            assertThatThrownBy(() -> categoryRepository.save(category)
+            ).isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("imageUrl Null")
+        void imageNull() {
+            Category category = new Category("hello", "color", null, "description");
+
+            assertThatThrownBy(() -> categoryRepository.save(category)
+            ).isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("Name, Color Null")
+        void nameColorNull() {
+            Category category = new Category(null, null, "imageUrl", "description");
+
+            assertThatThrownBy(() -> categoryRepository.save(category)
+            ).isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("Color 길이 8일때")
+        void ColorLength() {
+            Category category = new Category("name", "A".repeat(8), "imageUrl", "description");
+
+            assertThatThrownBy(() -> categoryRepository.save(category)
+            ).isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("이름 Unique")
+        void nameUnique() {
+            Category category1 = new Category("name", "color", "imageUrl", "description");
+            Category category2 = new Category("name", "color", "imageUrl", "description");
+            categoryRepository.save(category1);
+            assertThatThrownBy(() -> categoryRepository.save(category2)
+            ).isInstanceOf(DataIntegrityViolationException.class);
+        }
+    }
+}

--- a/src/test/java/gift/repository/MemberRepositoryTest.java
+++ b/src/test/java/gift/repository/MemberRepositoryTest.java
@@ -1,0 +1,75 @@
+package gift.repository;
+
+import gift.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@DisplayName("멤버 레포지토리 단위테스트")
+class MemberRepositoryTest {
+
+    private static final String EMAIL = "zzoe2346@git.com";
+    private static final String PASSWORD = "12345678";
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("이메일과 비밀번호로 멤버 찾기(for Login)")
+    void findMemberByEmailAndPassword() {
+        //Given
+        Member member = new Member(EMAIL, PASSWORD);
+        memberRepository.save(member);
+
+        //When
+        Optional<Member> foundMember = memberRepository.findByEmailAndPassword(EMAIL, PASSWORD);
+
+        //Then
+        assertThat(foundMember).isPresent()
+                .hasValueSatisfying(m -> {
+                    assertThat(m.getEmail()).isEqualTo(EMAIL);
+                    assertThat(m.getId()).isPositive();
+                });
+    }
+
+    @Test
+    @DisplayName("이메일로 멤버 찾기")
+    void findByEmail() {
+        //Given
+        Member member = new Member(EMAIL, PASSWORD);
+        Long savedMemberId = memberRepository.save(member).getId();
+
+        //When
+        Optional<Member> foundMember = memberRepository.findByEmail(EMAIL);
+
+        //Then
+        assertThat(foundMember).isPresent()
+                .hasValueSatisfying(m ->
+                        assertThat(m.getId()).isEqualTo(savedMemberId)
+                );
+    }
+
+    @Nested
+    @DisplayName("멤버 엔티티 테스트")
+    class EntityTest {
+        @Test
+        @DisplayName("이메일 중복 예외처리")
+        void emailDuplicate() {
+            Member member = new Member("a@naver.com", "1234");
+            memberRepository.save(member);
+
+            Member sameEmailMember = new Member("a@naver.com", "1");
+
+            assertThatThrownBy(() -> memberRepository.save(sameEmailMember))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+    }
+}

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -1,0 +1,121 @@
+package gift.repository;
+
+import gift.entity.Category;
+import gift.entity.Option;
+import gift.entity.Product;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@DisplayName("상품 레포지토리 단위테스트")
+class ProductRepositoryTest {
+
+    private final Category testCategory = new Category("교환권", "테스트", "테스트", "테스트");
+    @Autowired
+    private TestEntityManager testEntityManager;
+    @Autowired
+    private ProductRepository productRepository;
+
+    @BeforeEach
+    void setUp() {
+        testEntityManager.persist(testCategory);
+    }
+
+    @Test
+    @DisplayName("상품 저장")
+    void saveTest() {
+        // Given
+        Product product = new Product("아몬드", 500, "image.jpg", testCategory, List.of(new Option("option1", 1)));
+        Long savedProductId = productRepository.save(product).getId();
+
+        // When
+        Optional<Product> foundProduct = productRepository.findById(savedProductId);
+
+        // Then
+        assertThat(foundProduct).isPresent();
+        assertThat(foundProduct.get().getName()).isEqualTo("아몬드");
+    }
+
+    @Test
+    @DisplayName("상품 읽기(read)")
+    void readTest() {
+        // Given
+        Product product1 = new Product("아몬드", 500, "image.jpg", testCategory, List.of(new Option("option1", 1)));
+        Product product2 = new Product("초코", 5400, "image2.jpg", testCategory, List.of(new Option("option1", 1)));
+        productRepository.save(product1);
+        productRepository.save(product2);
+
+        // When
+        List<Product> foundProducts = productRepository.findAll();
+
+        // Then
+        assertThat(foundProducts).hasSize(2);
+        assertThat(foundProducts).containsExactly(product1, product2);
+    }
+
+    @Test
+    @DisplayName("상품 수정")
+    void updateTest() {
+        // Given
+        Product product = new Product("아몬드", 500, "image.jpg", testCategory, List.of(new Option("option1", 1)));
+        Product savedProduct = productRepository.save(product);
+
+        // When
+        savedProduct.update("아몬드봉봉", 600, "image.jpg", testCategory);
+
+        // Then
+        assertThat(savedProduct.getName()).isEqualTo("아몬드봉봉");
+    }
+
+    @Test
+    @DisplayName("상품 삭제")
+    void deleteTest() {
+        // Given
+        Product product = new Product("아몬드", 500, "image.jpg", testCategory, List.of(new Option("option1", 1)));
+        Product savedProduct = productRepository.save(product);
+        Long savedProductId = savedProduct.getId();
+
+        // When
+        productRepository.delete(savedProduct);
+        Optional<Product> deleteResult = productRepository.findById(savedProductId);
+
+        // Then
+        assertThat(deleteResult).isNotPresent();
+    }
+
+    @Nested
+    @DisplayName("상품 엔티티 테스트")
+    class EntityTest {
+        @Test
+        @DisplayName("Name Null")
+        void nameNull() {
+            List<Option> options = List.of(new Option("option", 1010));
+            Product product = new Product(null, 101, "img", testCategory, options);
+
+            assertThatThrownBy(() -> productRepository.save(product))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("이름 16자 일때 예외 발생")
+        void nameLength() {
+            List<Option> options = List.of(new Option("option", 1010));
+            Product product = new Product("1234".repeat(4), 101, "img", testCategory, options);
+
+            assertThatThrownBy(() -> productRepository.save(product))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+    }
+}

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -1,0 +1,100 @@
+package gift.repository;
+
+import gift.entity.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@DisplayName("위시 레포티토리 단위테스트")
+class WishRepositoryTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+    @Autowired
+    private WishRepository wishRepository;
+
+    private Member testMember;
+    private Product testProduct1;
+    private Product testProduct2;
+
+    @BeforeEach
+    void setUp() {
+        testMember = new Member("test@email.com", "password");
+        testEntityManager.persist(testMember);
+
+        Category testCategory = new Category("음식", "테스트", "테스트", "테스트");
+        testEntityManager.persist(testCategory);
+
+        testProduct1 = new Product("almond", 500, "almond.jpg", testCategory, List.of(new Option("optoin1", 1)));
+        testProduct2 = new Product("ice", 900, "ice.jpg", testCategory, List.of(new Option("optoin1", 1)));
+        testEntityManager.persist(testProduct1);
+        testEntityManager.persist(testProduct2);
+    }
+
+    @Test
+    @DisplayName("특정 멤버의 위시 전체 조회")
+    void findAllByMemberIdWithProduct() {
+        //Given
+        Wish testWish1 = new Wish(testMember, 100, testProduct1);
+        Wish testWish2 = new Wish(testMember, 2000, testProduct2);
+        wishRepository.save(testWish1);
+        wishRepository.save(testWish2);
+
+        //When
+        PageRequest pageable = PageRequest.of(0, 10);
+        List<Wish> wishes = wishRepository.findAllByMember(testMember, pageable).getContent();
+
+        //Then
+        assertThat(wishes).isNotEmpty()
+                .hasSize(2)
+                .containsExactly(testWish1, testWish2);
+
+        assertThat(testWish1.getProduct()).isEqualTo(testProduct1);
+    }
+
+    @Test
+    @DisplayName("멤버와 상품으로 위시 조회")
+    void findByMemberAndProduct() {
+        //Given
+        Wish testWish1 = new Wish(testMember, 100, testProduct1);
+        wishRepository.save(testWish1);
+
+        //When
+        Optional<Wish> wish = wishRepository.findByMemberAndProduct(testMember, testProduct1);
+
+        //Then
+        assertThat(wish).isPresent()
+                .hasValueSatisfying(w -> {
+                    assertThat(w).isEqualTo(testWish1);
+                    assertThat(w.getProduct()).isEqualTo(testProduct1);
+                });
+    }
+
+    @Nested
+    @DisplayName("위시 엔티티 테스트")
+    class EntityTest {
+        @Test
+        @DisplayName("생성된 날짜")
+        void dateCheck() {
+            Wish wish = new Wish(testMember, 100, testProduct1);
+
+            Wish save = wishRepository.save(wish);
+
+            assertThat(save.getCreatedTime())
+                    .isInstanceOf(LocalDateTime.class);
+        }
+
+    }
+}

--- a/src/test/java/gift/service/CategoryServiceTest.java
+++ b/src/test/java/gift/service/CategoryServiceTest.java
@@ -1,0 +1,193 @@
+package gift.service;
+
+import gift.dto.request.AddCategoryRequest;
+import gift.dto.request.UpdateCategoryRequest;
+import gift.dto.response.CategoryIdResponse;
+import gift.dto.response.CategoryResponse;
+import gift.entity.Category;
+import gift.exception.CategoryNameDuplicateException;
+import gift.exception.CategoryNotFoundException;
+import gift.repository.CategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("카테고리 서비스 단위테스트")
+class CategoryServiceTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @Test
+    @DisplayName("모든 카테고리 조회")
+    void getAllCategories() {
+        //Given
+        Category category1 = mock(Category.class);
+        Category category2 = mock(Category.class);
+        Category category3 = mock(Category.class);
+
+        List<Category> categoryList = List.of(
+                category1,
+                category2,
+                category3
+        );
+
+        when(category1.getName()).thenReturn("상품권");
+        when(category2.getName()).thenReturn("교환권");
+        when(category3.getName()).thenReturn("패션잡화");
+
+        when(categoryRepository.findAll()).thenReturn(categoryList);
+
+        //When
+        List<CategoryResponse> categoryResponses = categoryService.getAllCategoryResponses();
+
+        //Then
+        assertThat(categoryResponses)
+                .hasSize(3)
+                .extracting("name")
+                .containsExactly("상품권", "교환권", "패션잡화");
+    }
+
+    @Nested
+    @DisplayName("카테고리 id로 조회")
+    class Get {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //Given
+            Category wantCategory = new Category("원하는 카테고리", "test", "test", "test");
+            when(categoryRepository.findById(any())).thenReturn(Optional.of(wantCategory));
+
+            //When
+            Category result = categoryService.getCategory(any());
+
+            //Then
+            assertThat(result).isNotNull()
+                    .extracting("name", "color")
+                    .containsExactly("원하는 카테고리", "test");
+        }
+
+        @Test
+        @DisplayName("실패 - 해당 카테고리 존재 안함")
+        void fail() {
+            //Given
+            when(categoryRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+
+            //When Then
+            assertThatThrownBy(() -> categoryService.getCategory(any(Long.class)))
+                    .isInstanceOf(CategoryNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 추가")
+    class Add {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //Given
+            when(categoryRepository.existsByName(any())).thenReturn(false);
+
+            AddCategoryRequest request = new AddCategoryRequest("상품권", "색", "이미지주소", "설명");
+            Category category = mock(Category.class);
+
+            when(categoryRepository.save(any())).thenReturn(category);
+            when(category.getId()).thenReturn(1L);
+
+            //When
+            CategoryIdResponse response = categoryService.addCategory(request);
+
+            //Then
+            assertThat(response.id()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("실패 - 카테고리 이름 중복")
+        void fail() {
+            //Given
+            when(categoryRepository.existsByName(any())).thenReturn(true);
+            AddCategoryRequest request = new AddCategoryRequest("상품권", "색", "이미지주소", "설명");
+
+            //When Then
+            assertThatThrownBy(() -> categoryService.addCategory(request))
+                    .isInstanceOf(CategoryNameDuplicateException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 수정")
+    class Update {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //Given
+            Category existingCategory = new Category("기존", "기존", "기존", "기존");
+
+            UpdateCategoryRequest request = new UpdateCategoryRequest(1L, "새로움", "새로움", "뉴이미지", "설명");
+            when(categoryRepository.findById(1L)).thenReturn(Optional.of(existingCategory));
+
+            //When
+            categoryService.updateCategory(request);
+
+            //Then
+            assertThat(existingCategory.getName()).isEqualTo("새로움");
+        }
+
+        @Test
+        @DisplayName("실패 - 해당 카테고리 존재 안함")
+        void fail() {
+            //Given
+            when(categoryRepository.findById(1L)).thenReturn(Optional.empty());
+
+            UpdateCategoryRequest request = new UpdateCategoryRequest(1L, "새로움", "새로움", "뉴이미지", "설명");
+
+            //When Then
+            assertThatThrownBy(() -> categoryService.updateCategory(request))
+                    .isInstanceOf(CategoryNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 삭제")
+    class Delete {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //Given
+            Category deleteTargetCategory = new Category("타겟", "타겟", "타겟", "타겟");
+            when(categoryRepository.findById(1L)).thenReturn(Optional.of(deleteTargetCategory));
+
+            //When
+            categoryService.deleteCategory(1L);
+
+            //Then
+            verify(categoryRepository).delete(deleteTargetCategory);
+        }
+
+        @Test
+        @DisplayName("실패 - 해당 카테고리 존재 안함")
+        void fail() {
+            //Given
+            when(categoryRepository.findById(1L)).thenReturn(Optional.empty());
+
+            //When Then
+            assertThatThrownBy(() -> categoryService.deleteCategory(1L))
+                    .isInstanceOf(CategoryNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/gift/service/ProductServiceTest.java
+++ b/src/test/java/gift/service/ProductServiceTest.java
@@ -1,0 +1,262 @@
+package gift.service;
+
+import gift.dto.request.AddProductRequest;
+import gift.dto.request.OptionRequest;
+import gift.dto.request.UpdateProductRequest;
+import gift.dto.response.AddedOptionIdResponse;
+import gift.dto.response.AddedProductIdResponse;
+import gift.dto.response.OptionResponse;
+import gift.dto.response.ProductResponse;
+import gift.entity.Category;
+import gift.entity.Option;
+import gift.entity.Product;
+import gift.exception.ProductNotFoundException;
+import gift.repository.ProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("상품 서비스 단위테스트")
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+    @Mock
+    private CategoryService categoryService;
+    @Mock
+    private OptionService optionService;
+    @InjectMocks
+    private ProductService productService;
+
+    @Test
+    @DisplayName("상품 추가(with Option)")
+    void addProduct() {
+        //Give
+        AddProductRequest request = new AddProductRequest("productName", 100, "img", 1L, List.of(new OptionRequest("option", 1010)));
+        Category category = new Category("CategoryName", "color", "description", "imageUrl");
+
+        when(categoryService.getCategory(request.categoryId())).thenReturn(category);
+
+        Product savedProduct = mock(Product.class);
+
+        when(productRepository.save(any(Product.class))).thenReturn(savedProduct);
+        when(savedProduct.getId()).thenReturn(1L);
+
+        //When
+        AddedProductIdResponse addedProductIdResponse = productService.addProduct(request);
+
+        //Then
+        assertThat(addedProductIdResponse.id()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("싱품에 옵션 추가하기(기존상황에서 추가하는것)")
+    void addOptionToProduct() {
+        //Given
+        Long productId = 1L;
+        Category category = new Category("CategoryName", "color", "description", "imageUrl");
+        List<Option> options = List.of(new Option("option", 1010));
+        Product product = new Product("product", 101, "img", category, options);
+
+        OptionRequest optionRequest = new OptionRequest("newOption", 1010);
+        Option option = Mockito.mock(Option.class);
+
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(optionService.saveOption(any(), any())).thenReturn(option);
+        when(option.getId()).thenReturn(1L);
+
+        //When
+        AddedOptionIdResponse addedOptionIdResponse = productService.addOptionToProduct(productId, optionRequest);
+
+        //Then
+        assertThat(addedOptionIdResponse.optionId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("상품(Response) 얻기")
+    void GetResponses() {
+        //Given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Category category = new Category("CategoryName", "color", "description", "imageUrl");
+        List<Option> options = List.of(new Option("option", 1010));
+        Product product = new Product("product", 101, "img", category, options);
+
+        Page<Product> page = new PageImpl<>(List.of(product));
+
+        when(productRepository.findAll(pageable)).thenReturn(page);
+
+        //When
+        Page<ProductResponse> productResponses = productService.getProductResponses(pageable);
+
+        //Then
+        assertThat(productResponses.getContent())
+                .hasSize(1)
+                .first()
+                .isInstanceOf(ProductResponse.class)
+                .extracting("name", "price")
+                .containsExactly("product", 101);
+    }
+
+    @Nested
+    @DisplayName("상품(Entity) 얻기")
+    class GetEntity {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //Given
+            Category category = new Category("CategoryName", "color", "description", "imageUrl");
+            List<Option> options = List.of(new Option("option", 1010));
+            Product product = new Product("product", 101, "img", category, options);
+            when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+
+            //When
+            Product resultProduct = productService.getProduct(1L);
+
+            //Then
+            assertThat(resultProduct.getName()).isEqualTo("product");
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 상품")
+        void fail() {
+            //Given
+            when(productRepository.findById(1L)).thenReturn(Optional.empty());
+
+            //When Then
+            assertThatThrownBy(() -> productService.getProduct(1L))
+                    .isInstanceOf(ProductNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 수정")
+    class Update {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //Given
+            UpdateProductRequest request = new UpdateProductRequest(1L, "updateName", 10, "img", 1L);
+
+            Category category = new Category("CategoryName", "color", "description", "imageUrl");
+            List<Option> options = List.of(new Option("option", 1010));
+            Product product = new Product("oldName", 101, "img", category, options);
+
+            when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+            when(categoryService.getCategory(request.categoryId())).thenReturn(category);
+
+            //When
+            productService.updateProduct(request);
+
+            //Then
+            assertThat(product.getName()).isEqualTo("updateName");
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 상품")
+        void fail() {
+            //Given
+            UpdateProductRequest request = new UpdateProductRequest(1L, "updateName", 10, "img", 1L);
+
+            when(productRepository.findById(1L)).thenReturn(Optional.empty());
+
+            //When Then
+            assertThatThrownBy(() -> productService.updateProduct(request))
+                    .isInstanceOf(ProductNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 삭제")
+    class Delete {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //Given
+            Long productId = 1L;
+
+            Category category = new Category("CategoryName", "color", "description", "imageUrl");
+            List<Option> options = List.of(new Option("option", 1010));
+            Product product = new Product("oldName", 101, "img", category, options);
+
+            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+
+            //When
+            productService.deleteProduct(productId);
+
+            //Then
+            verify(productRepository, times(1)).delete(product);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 상품")
+        void fail() {
+            //Given
+            Long productId = 1L;
+
+            when(productRepository.findById(productId)).thenReturn(Optional.empty());
+
+            //When Then
+            assertThatThrownBy(() -> productService.deleteProduct(productId))
+                    .isInstanceOf(ProductNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("특정 상품 옵션(Response) 얻기")
+    class OptionGet {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //Given
+            Long productId = 1L;
+
+            Category category = new Category("CategoryName", "color", "description", "imageUrl");
+            List<Option> options = List.of(new Option("option", 1010));
+            Product product = new Product("oldName", 101, "img", category, options);
+
+            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+
+            //When
+            List<OptionResponse> optionResponses = productService.getOptionResponses(productId);
+
+            //Then
+            assertThat(optionResponses).first()
+                    .isInstanceOf(OptionResponse.class)
+                    .extracting("name", "quantity")
+                    .containsExactly("option", 1010);
+
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 상품")
+        void fail() {
+            //Given
+            Long productId = 1L;
+
+            when(productRepository.findById(productId)).thenReturn(Optional.empty());
+
+            //When Then
+            assertThatThrownBy(() -> productService.deleteProduct(productId))
+                    .isInstanceOf(ProductNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/gift/service/ProductServiceTest.java
+++ b/src/test/java/gift/service/ProductServiceTest.java
@@ -80,7 +80,7 @@ class ProductServiceTest {
         Option option = Mockito.mock(Option.class);
 
         when(productRepository.findById(productId)).thenReturn(Optional.of(product));
-        when(optionService.saveOption(any(), any())).thenReturn(option);
+        when(optionService.saveOption(any())).thenReturn(option);
         when(option.getId()).thenReturn(1L);
 
         //When

--- a/src/test/java/gift/service/WishServiceTest.java
+++ b/src/test/java/gift/service/WishServiceTest.java
@@ -1,0 +1,197 @@
+package gift.service;
+
+import gift.dto.request.WishRequest;
+import gift.dto.response.WishProductResponse;
+import gift.entity.Member;
+import gift.entity.Option;
+import gift.entity.Product;
+import gift.entity.Wish;
+import gift.exception.WishAlreadyExistsException;
+import gift.exception.WishNotFoundException;
+import gift.repository.WishRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("위시리스트 서비스 단위테스트")
+class WishServiceTest {
+
+    @Mock
+    private WishRepository wishRepository;
+    @Mock
+    private ProductService productService;
+    @Mock
+    private MemberService memberService;
+    @InjectMocks
+    private WishService wishService;
+
+    @Test
+    @DisplayName("멤버의 모든 위시리스트 상품 조회")
+    void getWishProductsByMemberId() {
+        //Given
+        Long memberId = 1L;
+        Member member = new Member("test@email.com", "password");
+        Product product = new Product("name", 1000, "imageUrl", null, List.of(new Option("option1", 100)));
+        Wish wish = new Wish(member, 1, product);
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<Wish> wishPage = new PageImpl<>(List.of(wish), pageable, 1);
+
+        when(memberService.getMember(memberId)).thenReturn(member);
+        when(wishRepository.findAllByMember(member, pageable)).thenReturn(wishPage);
+
+        //When
+        Page<WishProductResponse> responsePage = wishService.getWishProductResponses(memberId, pageable);
+
+        //Then
+        assertThat(responsePage.getContent()).hasSize(1);
+        assertThat(responsePage.getContent().get(0))
+                .extracting("productName", "productAmount")
+                .containsExactly("name", 1);
+    }
+
+    @Nested
+    @DisplayName("상품을 위시리스트에 추가")
+    class AddProductToWishList {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //Given
+            Long memberId = 1L;
+            WishRequest request = new WishRequest(1L, 1);
+            Member member = new Member("test@email.com", "password");
+            Product product = new Product("name", 1000, "imageUrl", null, List.of(new Option("option1", 100)));
+
+            when(memberService.getMember(memberId)).thenReturn(member);
+            when(productService.getProduct(request.productId())).thenReturn(product);
+            when(wishRepository.existsByMemberAndProduct(member, product)).thenReturn(false);
+
+            //When
+            wishService.addProductToWish(memberId, request);
+
+            //Then
+            verify(wishRepository).save(any(Wish.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 존재하는 위시")
+        void fail() {
+            // Given
+            Long memberId = 1L;
+            WishRequest request = new WishRequest(1L, 1);
+            Member member = new Member("test@email.com", "password");
+            Product product = new Product("name", 1000, "imageUrl", null, List.of(new Option("option1", 100)));
+
+            when(memberService.getMember(memberId)).thenReturn(member);
+            when(productService.getProduct(request.productId())).thenReturn(product);
+            when(wishRepository.existsByMemberAndProduct(member, product)).thenReturn(true);
+
+            //  When Then
+            assertThatThrownBy(() -> wishService.addProductToWish(memberId, request))
+                    .isInstanceOf(WishAlreadyExistsException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("위시리스트에서 상품 삭제")
+    class DeleteProductInWishList {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //Given
+            Long memberId = 1L;
+            Long productId = 1L;
+            Member member = new Member("test@email.com", "password");
+            Product product = new Product("name", 1000, "imageUrl", null, List.of(new Option("option1", 100)));
+            Wish wish = new Wish(member, 1, product);
+
+            when(memberService.getMember(memberId)).thenReturn(member);
+            when(productService.getProduct(productId)).thenReturn(product);
+            when(wishRepository.findByMemberAndProduct(member, product)).thenReturn(Optional.of(wish));
+
+            //When
+            wishService.deleteProductInWish(memberId, productId);
+
+            //Then
+            verify(wishRepository).delete(wish);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 위시")
+        void fail() {
+            //Given
+            Long memberId = 1L;
+            Long productId = 1L;
+            Member member = new Member("test@email.com", "password");
+            Product product = new Product("name", 1000, "imageUrl", null, List.of(new Option("option1", 100)));
+
+            when(memberService.getMember(memberId)).thenReturn(member);
+            when(productService.getProduct(productId)).thenReturn(product);
+            when(wishRepository.findByMemberAndProduct(member, product)).thenReturn(Optional.empty());
+
+            //When Then
+            assertThatThrownBy(() -> wishService.deleteProductInWish(memberId, productId))
+                    .isInstanceOf(WishNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("위시리스트 상품 수량 업데이트")
+    class UpdateWishProductAmount {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //Given
+            Long memberId = 1L;
+            WishRequest request = new WishRequest(1L, 10);
+            Member member = new Member("test@email.com", "password");
+            Product product = new Product("name", 1000, "imageUrl", null, List.of(new Option("option1", 100)));
+            Wish wish = new Wish(member, 1, product);
+
+            when(memberService.getMember(memberId)).thenReturn(member);
+            when(productService.getProduct(request.productId())).thenReturn(product);
+            when(wishRepository.findByMemberAndProduct(member, product)).thenReturn(Optional.of(wish));
+
+            //When
+            wishService.updateWishProductQuantity(memberId, request);
+
+            //Then
+            assertThat(wish.getQuantity()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 위시")
+        void fail() {
+            //Given
+            Long memberId = 1L;
+            WishRequest request = new WishRequest(1L, 10);
+            Member member = new Member("test@email.com", "password");
+            Product product = new Product("name", 1000, "imageUrl", null, List.of(new Option("option1", 100)));
+
+            when(memberService.getMember(memberId)).thenReturn(member);
+            when(productService.getProduct(request.productId())).thenReturn(product);
+            when(wishRepository.findByMemberAndProduct(member, product)).thenReturn(Optional.empty());
+
+            //When Then
+            assertThatThrownBy(() -> wishService.updateWishProductQuantity(memberId, request))
+                    .isInstanceOf(WishNotFoundException.class);
+        }
+    }
+}


### PR DESCRIPTION
엔티티, 트랜잭션이 아직 어렵고 이해가안가는 부분이 많은거같습니다. ㅜ 멘토님의 피드백과 다양한 매체로 공부해보겠습니다.

```
@Transactional
    public AddedOptionIdResponse addOptionToProduct(Long productId, OptionRequest optionRequest) {
        Product product = getProduct(productId);

        Option savedOption = optionService.saveOption(optionRequest);
        product.addOption(savedOption);

        return new AddedOptionIdResponse(savedOption.getId());
    }
```
위 코드에서 제 의도를 명확히 설명 못드린거같아서 다시 말씀드려봅니다.

이 코드에서 save를 따로해준 이유는 다음과 같은 기능을 희망하였기 때문입니다. 

> 요청: 옵션을 상품에 추가 -> 응답: 새로 추가된 옵션 ID 반환 

그런데 
```
@Transactional
    public AddedOptionIdResponse addOptionToProduct(Long productId, OptionRequest optionRequest) {
        Product product = getProduct(productId);

        Option savedOption = new Option(optionRequest.name(), optionRequest.quantity());
        product.addOption(savedOption);

        return new AddedOptionIdResponse(savedOption.getId());
    }
``` 
이 코드에서
`@Transactional`을 적용하여도 아직 `savedOption`이 영속화 되기 전이라 `savedOption.getId()`의 값이 `null`이 반환되는것이라는것을 검색과 postman으로 테스트를 해보며 알게되었습니다. 그래서 중간에 영속화를 하자는 생각으로 `optionService.saveOption(optionRequest);`를 추가하여 보았습니다.

혹시, 이게 옵션이 상품에 종속되어 있으니 처음부터 option ID를 반환 안시키는것이 타당한것일까요? 계속 코드를 보다보니 이렇게 중간에 영속화가 강요되는것이 트랜잭션의 일관성에도 안맞는것 같고, 괜히 코드가 복잡해진것 같다는 생각이 듭니다.

---
**그리고** "`null`이 나오는데 진짜 저장이 되는가?" 하는 의문이 있었는데 이번에 멘토님의 리뷰를 참고하여 데이터베이스를 확인해보았습니다.
```
@Transactional
    public AddedOptionIdResponse addOptionToProduct(Long productId, OptionRequest optionRequest) {
        Product product = getProduct(productId);

        Option savedOption = new Option(optionRequest.name(), optionRequest.quantity());
        product.addOption(savedOption);

        return new AddedOptionIdResponse(savedOption.getId());
    }
``` 
이 코드를 활용해`savedOption.getId()`에서는 `null`이 나오지만 데이터베이스에서는 정상적으로 id가 등록된것을 확인할 수 있었습니다.

바로 전에 주신 피드백 적용하였습니다. 

- 연관관계 편의 메서드를 Product Entity의  `addOption()`에 적용시켰습니다.
- `addOption()`에 `checkDuplicateOptionName()`을 추가하여 옵션 추가시 옵션 이름 중복에대한 유효성 검사 누락을 방지하였습니다.
- `option.getName().equals(newOptionName)` ->`option.isSameName(newOptionName)`로 get을 안쓰도록 하였습니다.

리뷰해주신 내용 계속 참고하면서 공부하고 코드에 적용해보겠습니다.
이번 주도 잘 부탁드리겠습니다.
감사합니다!