### PR TITLE
 경북대 BE_배규민 5주차 과제 (3단계)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.3.1'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/gift/advice/SwaggerConfig.java
+++ b/src/main/java/gift/advice/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package gift.advice;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        );
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+    private Info apiInfo() {
+        return new Info()
+                .title("API Test")
+                .description("Let's practice Swagger UI")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/gift/authentication/infrastructure/configuration/CustomJwtFilter.java
+++ b/src/main/java/gift/authentication/infrastructure/configuration/CustomJwtFilter.java
@@ -68,7 +68,10 @@ public class CustomJwtFilter extends OncePerRequestFilter {
 
     private boolean shouldSkipRequest(HttpServletRequest request) {
         String path = request.getRequestURI();
-        return path.startsWith("/api/auth") || path.startsWith("/api/oauth");
+        return path.startsWith("/api/auth")
+                || path.startsWith("/api/oauth")
+                || path.startsWith("/swagger-ui")
+                || path.startsWith("/v3/api-docs");
     }
 
     private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode) {

--- a/src/main/java/gift/authentication/restapi/AuthenticationController.java
+++ b/src/main/java/gift/authentication/restapi/AuthenticationController.java
@@ -8,12 +8,18 @@ import gift.core.domain.authentication.Token;
 import gift.core.domain.user.User;
 import gift.core.domain.user.UserAccount;
 import gift.core.domain.user.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "인증/인가")
 public class AuthenticationController {
     private final UserService userService;
     private final AuthenticationService authenticationService;
@@ -28,12 +34,19 @@ public class AuthenticationController {
     }
 
     @PostMapping("/api/auth/login")
+    @Operation(summary = "로그인 API", description = "이메일과 비밀번호로 로그인을 수행합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그인 성공 시 액세스 토큰을 생성하여 반환합니다.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = LoginResponse.class))
+    )
     public LoginResponse login(@RequestBody LoginRequest request) {
         Token token = authenticationService.authenticate(request.email(), request.password());
         return LoginResponse.of(token);
     }
 
     @PostMapping("/api/auth/signup")
+    @Operation(summary = "회원가입 API", description = "이름, 이메일, 비밀번호로 회원가입을 수행합니다.")
     public void signUp(@RequestBody SignUpRequest request) {
         userService.registerUser(userOf(request));
     }

--- a/src/main/java/gift/authentication/restapi/AuthenticationController.java
+++ b/src/main/java/gift/authentication/restapi/AuthenticationController.java
@@ -1,5 +1,6 @@
 package gift.authentication.restapi;
 
+import gift.advice.ErrorResponse;
 import gift.authentication.restapi.dto.request.LoginRequest;
 import gift.authentication.restapi.dto.request.SignUpRequest;
 import gift.authentication.restapi.dto.response.LoginResponse;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,10 +37,19 @@ public class AuthenticationController {
 
     @PostMapping("/api/auth/login")
     @Operation(summary = "로그인 API", description = "이메일과 비밀번호로 로그인을 수행합니다.")
-    @ApiResponse(
-            responseCode = "200",
-            description = "로그인 성공 시 액세스 토큰을 생성하여 반환합니다.",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = LoginResponse.class))
+    @ApiResponses(
+           value = {
+                     @ApiResponse(
+                            responseCode = "200",
+                            description = "로그인 성공 시 액세스 토큰을 생성하여 반환합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = LoginResponse.class))
+                     ),
+                     @ApiResponse(
+                            responseCode = "400",
+                            description = "로그인 실패 시 반환합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                     )
+           }
     )
     public LoginResponse login(@RequestBody LoginRequest request) {
         Token token = authenticationService.authenticate(request.email(), request.password());
@@ -47,6 +58,19 @@ public class AuthenticationController {
 
     @PostMapping("/api/auth/signup")
     @Operation(summary = "회원가입 API", description = "이름, 이메일, 비밀번호로 회원가입을 수행합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "회원가입 성공 시 반환합니다."
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "회원가입 실패 시 반환합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
+    )
     public void signUp(@RequestBody SignUpRequest request) {
         userService.registerUser(userOf(request));
     }

--- a/src/main/java/gift/authentication/restapi/KakaoOAuthController.java
+++ b/src/main/java/gift/authentication/restapi/KakaoOAuthController.java
@@ -4,11 +4,16 @@ import gift.authentication.restapi.dto.response.LoginResponse;
 import gift.core.domain.authentication.OAuthService;
 import gift.core.domain.authentication.OAuthType;
 import gift.core.domain.authentication.Token;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "OAuth")
 public class KakaoOAuthController {
     private final OAuthService oAuthService;
 
@@ -17,6 +22,13 @@ public class KakaoOAuthController {
     }
 
     @GetMapping("/api/oauth/kakao")
+    @Operation(summary = "카카오 로그인 API", description = "카카오 로그인을 수행합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "카카오 액세스 토큰을 반환합니다",
+            content = @Content(mediaType = "application/json"),
+            useReturnTypeSchema = true
+    )
     public LoginResponse login(@RequestParam("code") String code) {
         Token token = oAuthService.authenticate(OAuthType.KAKAO, code);
 

--- a/src/main/java/gift/authentication/restapi/KakaoOAuthController.java
+++ b/src/main/java/gift/authentication/restapi/KakaoOAuthController.java
@@ -1,12 +1,15 @@
 package gift.authentication.restapi;
 
+import gift.advice.ErrorResponse;
 import gift.authentication.restapi.dto.response.LoginResponse;
 import gift.core.domain.authentication.OAuthService;
 import gift.core.domain.authentication.OAuthType;
 import gift.core.domain.authentication.Token;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,11 +26,19 @@ public class KakaoOAuthController {
 
     @GetMapping("/api/oauth/kakao")
     @Operation(summary = "카카오 로그인 API", description = "카카오 로그인을 수행합니다.")
-    @ApiResponse(
-            responseCode = "200",
-            description = "카카오 액세스 토큰을 반환합니다",
-            content = @Content(mediaType = "application/json"),
-            useReturnTypeSchema = true
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "카카오 로그인 성공 시 액세스 토큰을 생성하여 반환합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = LoginResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "카카오 메시지 전달 실패 시 반환합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
     )
     public LoginResponse login(@RequestParam("code") String code) {
         Token token = oAuthService.authenticate(OAuthType.KAKAO, code);

--- a/src/main/java/gift/order/restapi/OrderController.java
+++ b/src/main/java/gift/order/restapi/OrderController.java
@@ -1,16 +1,26 @@
 package gift.order.restapi;
 
+import gift.advice.ErrorResponse;
 import gift.advice.GatewayToken;
 import gift.advice.LoggedInUser;
 import gift.core.domain.order.Order;
 import gift.core.domain.order.OrderService;
 import gift.order.restapi.dto.OrderRequest;
 import gift.order.restapi.dto.OrderResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "주문")
 public class OrderController {
     private final OrderService orderService;
 
@@ -19,6 +29,33 @@ public class OrderController {
     }
 
     @PostMapping("/api/orders")
+    @Operation(
+            summary = "상품 주문",
+            description = "상품을 주문합니다.",
+            parameters = {
+                    @Parameter(
+                            in = ParameterIn.HEADER,
+                            name = "X-GATEWAY-TOKEN",
+                            required = true,
+                            schema = @Schema(type = "string"),
+                            description = "카카오톡 메시지를 보내기 위한 액세스 토큰입니다."
+                    )
+            }
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "상품을 주문합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = OrderResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "주문 실패 시 반환합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
+    )
     public OrderResponse orderProduct(
             @LoggedInUser Long userId,
             @GatewayToken String gatewayAccessToken,

--- a/src/main/java/gift/product/restapi/ProductCategoryController.java
+++ b/src/main/java/gift/product/restapi/ProductCategoryController.java
@@ -4,6 +4,11 @@ import gift.core.PagedDto;
 import gift.core.domain.product.ProductCategory;
 import gift.core.domain.product.ProductCategoryService;
 import gift.product.restapi.dto.response.PagedCategoryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/categories")
+@Tag(name = "상품 카테고리")
 public class ProductCategoryController {
     private final ProductCategoryService productCategoryService;
 
@@ -20,6 +26,12 @@ public class ProductCategoryController {
     }
 
     @GetMapping
+    @Operation(summary = "카테고리 목록 조회", description = "카테고리 목록을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "카테고리 목록을 조회합니다.",
+            content = @Content(mediaType = "application/json", schema = @Schema(contentSchema = PagedCategoryResponse.class))
+    )
     public PagedCategoryResponse getCategories(
             @PageableDefault Pageable pageable
     ) {

--- a/src/main/java/gift/product/restapi/ProductCategoryController.java
+++ b/src/main/java/gift/product/restapi/ProductCategoryController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -35,10 +36,14 @@ public class ProductCategoryController {
                     @Parameter(name = "size", description = "페이지 크기 (기본 값 : 10)")
             }
     )
-    @ApiResponse(
-            responseCode = "200",
-            description = "카테고리 목록을 조회합니다.",
-            content = @Content(mediaType = "application/json", schema = @Schema(contentSchema = PagedCategoryResponse.class))
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "카테고리 목록을 조회합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(contentSchema = PagedCategoryResponse.class))
+                    )
+            }
     )
     public PagedCategoryResponse getCategories(
             @PageableDefault Pageable pageable

--- a/src/main/java/gift/product/restapi/ProductCategoryController.java
+++ b/src/main/java/gift/product/restapi/ProductCategoryController.java
@@ -5,6 +5,7 @@ import gift.core.domain.product.ProductCategory;
 import gift.core.domain.product.ProductCategoryService;
 import gift.product.restapi.dto.response.PagedCategoryResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -26,7 +27,14 @@ public class ProductCategoryController {
     }
 
     @GetMapping
-    @Operation(summary = "카테고리 목록 조회", description = "카테고리 목록을 조회합니다.")
+    @Operation(
+            summary = "카테고리 목록 조회",
+            description = "카테고리 목록을 조회합니다.",
+            parameters = {
+                    @Parameter(name = "page", description = "페이지 번호 (기본 값 : 0)"),
+                    @Parameter(name = "size", description = "페이지 크기 (기본 값 : 10)")
+            }
+    )
     @ApiResponse(
             responseCode = "200",
             description = "카테고리 목록을 조회합니다.",

--- a/src/main/java/gift/product/restapi/ProductController.java
+++ b/src/main/java/gift/product/restapi/ProductController.java
@@ -10,6 +10,7 @@ import gift.product.restapi.dto.request.ProductUpdateRequest;
 import gift.product.restapi.dto.response.PagedProductResponse;
 import gift.product.restapi.dto.response.ProductResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -31,7 +32,14 @@ public class ProductController {
     }
 
     @GetMapping("/api/products")
-    @Operation(summary = "상품 목록 조회", description = "상품 목록을 조회합니다.")
+    @Operation(
+            summary = "상품 목록 조회",
+            description = "상품 목록을 조회합니다.",
+            parameters = {
+                    @Parameter(name = "page", description = "페이지 번호 (기본 값 : 0)"),
+                    @Parameter(name = "size", description = "페이지 크기 (기본 값 : 10)")
+            }
+    )
     @ApiResponse(
             responseCode = "200",
             description = "상품 목록을 조회합니다.",
@@ -45,7 +53,13 @@ public class ProductController {
     }
 
     @GetMapping("/api/products/{id}")
-    @Operation(summary = "상품 조회", description = "상품을 조회합니다.")
+    @Operation(
+            summary = "상품 조회",
+            description = "상품을 조회합니다.",
+            parameters = {
+                    @Parameter(name = "id", description = "상품 ID")
+            }
+    )
     @ApiResponse(
             responseCode = "200",
             description = "상품을 조회합니다.",
@@ -69,7 +83,13 @@ public class ProductController {
     }
 
     @PutMapping("/api/products/{id}")
-    @Operation(summary = "상품 수정", description = "상품을 수정합니다.")
+    @Operation(
+            summary = "상품 수정",
+            description = "상품을 수정합니다.",
+            parameters = {
+                    @Parameter(name = "id", description = "상품 ID")
+            }
+    )
     @ApiResponse(
             responseCode = "200",
             description = "상품을 수정합니다."
@@ -92,7 +112,13 @@ public class ProductController {
     }
 
     @DeleteMapping("/api/products/{id}")
-    @Operation(summary = "상품 삭제", description = "상품을 삭제합니다.")
+    @Operation(
+            summary = "상품 삭제",
+            description = "상품을 삭제합니다.",
+            parameters = {
+                    @Parameter(name = "id", description = "상품 ID")
+            }
+    )
     @ApiResponse(
             responseCode = "200",
             description = "상품을 삭제합니다."

--- a/src/main/java/gift/product/restapi/ProductController.java
+++ b/src/main/java/gift/product/restapi/ProductController.java
@@ -9,6 +9,11 @@ import gift.product.restapi.dto.request.ProductCreateRequest;
 import gift.product.restapi.dto.request.ProductUpdateRequest;
 import gift.product.restapi.dto.response.PagedProductResponse;
 import gift.product.restapi.dto.response.ProductResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +21,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Tag(name = "상품")
 public class ProductController {
     private final ProductService productService;
 
@@ -25,6 +31,12 @@ public class ProductController {
     }
 
     @GetMapping("/api/products")
+    @Operation(summary = "상품 목록 조회", description = "상품 목록을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "상품 목록을 조회합니다.",
+            content = @Content(mediaType = "application/json", schema = @Schema(contentSchema = PagedProductResponse.class))
+    )
     public PagedProductResponse getAllProducts(
             @PageableDefault(size = 10) Pageable pageable
     ) {
@@ -33,11 +45,22 @@ public class ProductController {
     }
 
     @GetMapping("/api/products/{id}")
+    @Operation(summary = "상품 조회", description = "상품을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "상품을 조회합니다.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductResponse.class))
+    )
     public ProductResponse getProduct(@PathVariable Long id) {
         return ProductResponse.from(productService.get(id));
     }
 
     @PostMapping("/api/products")
+    @Operation(summary = "상품 등록", description = "상품을 등록합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "상품을 등록합니다."
+    )
     public void addProduct(
             @Valid @RequestBody ProductCreateRequest request
     ) {
@@ -46,6 +69,11 @@ public class ProductController {
     }
 
     @PutMapping("/api/products/{id}")
+    @Operation(summary = "상품 수정", description = "상품을 수정합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "상품을 수정합니다."
+    )
     public void updateProduct(
             @PathVariable Long id,
             @Valid @RequestBody ProductUpdateRequest request
@@ -64,6 +92,11 @@ public class ProductController {
     }
 
     @DeleteMapping("/api/products/{id}")
+    @Operation(summary = "상품 삭제", description = "상품을 삭제합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "상품을 삭제합니다."
+    )
     public void deleteProduct(@PathVariable Long id) {
         productService.remove(id);
     }

--- a/src/main/java/gift/product/restapi/ProductController.java
+++ b/src/main/java/gift/product/restapi/ProductController.java
@@ -1,5 +1,6 @@
 package gift.product.restapi;
 
+import gift.advice.ErrorResponse;
 import gift.core.PagedDto;
 import gift.core.domain.product.Product;
 import gift.core.domain.product.ProductCategory;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,10 +62,19 @@ public class ProductController {
                     @Parameter(name = "id", description = "상품 ID")
             }
     )
-    @ApiResponse(
-            responseCode = "200",
-            description = "상품을 조회합니다.",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductResponse.class))
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "상품을 조회합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "상품을 찾을 수 없습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
     )
     public ProductResponse getProduct(@PathVariable Long id) {
         return ProductResponse.from(productService.get(id));
@@ -71,9 +82,18 @@ public class ProductController {
 
     @PostMapping("/api/products")
     @Operation(summary = "상품 등록", description = "상품을 등록합니다.")
-    @ApiResponse(
-            responseCode = "200",
-            description = "상품을 등록합니다."
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "상품을 등록합니다."
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "상품 등록 실패 시 반환합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
     )
     public void addProduct(
             @Valid @RequestBody ProductCreateRequest request
@@ -90,9 +110,23 @@ public class ProductController {
                     @Parameter(name = "id", description = "상품 ID")
             }
     )
-    @ApiResponse(
-            responseCode = "200",
-            description = "상품을 수정합니다."
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "상품을 수정합니다."
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "상품을 찾을 수 없습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "상품 수정 실패 시 반환합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
     )
     public void updateProduct(
             @PathVariable Long id,
@@ -119,9 +153,18 @@ public class ProductController {
                     @Parameter(name = "id", description = "상품 ID")
             }
     )
-    @ApiResponse(
-            responseCode = "200",
-            description = "상품을 삭제합니다."
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "상품을 삭제합니다."
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "상품을 찾을 수 없습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
     )
     public void deleteProduct(@PathVariable Long id) {
         productService.remove(id);

--- a/src/main/java/gift/product/restapi/ProductOptionController.java
+++ b/src/main/java/gift/product/restapi/ProductOptionController.java
@@ -3,12 +3,19 @@ package gift.product.restapi;
 import gift.core.domain.product.ProductOptionService;
 import gift.product.restapi.dto.request.ProductOptionRegisterRequest;
 import gift.product.restapi.dto.response.ProductOptionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/products")
+@Tag(name = "상품 옵션")
 public class ProductOptionController {
     private final ProductOptionService productOptionService;
 
@@ -17,6 +24,12 @@ public class ProductOptionController {
     }
 
     @GetMapping("/{productId}/options")
+    @Operation(summary = "상품 옵션 목록 조회", description = "상품 옵션 목록을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "상품 옵션 목록을 조회합니다.",
+            content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = ProductOptionResponse.class)))
+    )
     public List<ProductOptionResponse> getOptions(
             @PathVariable("productId") Long productId
     ) {
@@ -28,6 +41,11 @@ public class ProductOptionController {
     }
 
     @PostMapping("/{productId}/options")
+    @Operation(summary = "상품 옵션 등록", description = "상품에 옵션을 등록합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "상품에 옵션을 등록합니다."
+    )
     public void registerOption(
             @PathVariable Long productId,
             @RequestBody ProductOptionRegisterRequest request
@@ -36,6 +54,11 @@ public class ProductOptionController {
     }
 
     @DeleteMapping("/{productId}/options/{optionId}")
+    @Operation(summary = "상품 옵션 삭제", description = "상품에서 옵션을 삭제합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "상품에서 옵션을 삭제합니다."
+    )
     public void deleteOption(
             @PathVariable Long productId,
             @PathVariable Long optionId

--- a/src/main/java/gift/product/restapi/ProductOptionController.java
+++ b/src/main/java/gift/product/restapi/ProductOptionController.java
@@ -4,6 +4,7 @@ import gift.core.domain.product.ProductOptionService;
 import gift.product.restapi.dto.request.ProductOptionRegisterRequest;
 import gift.product.restapi.dto.response.ProductOptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,7 +25,13 @@ public class ProductOptionController {
     }
 
     @GetMapping("/{productId}/options")
-    @Operation(summary = "상품 옵션 목록 조회", description = "상품 옵션 목록을 조회합니다.")
+    @Operation(
+            summary = "상품 옵션 목록 조회",
+            description = "상품 옵션 목록을 조회합니다.",
+            parameters = {
+                    @Parameter(name = "productId", description = "상품 ID")
+            }
+    )
     @ApiResponse(
             responseCode = "200",
             description = "상품 옵션 목록을 조회합니다.",
@@ -41,7 +48,13 @@ public class ProductOptionController {
     }
 
     @PostMapping("/{productId}/options")
-    @Operation(summary = "상품 옵션 등록", description = "상품에 옵션을 등록합니다.")
+    @Operation(
+            summary = "상품 옵션 등록",
+            description = "상품에 옵션을 등록합니다.",
+            parameters = {
+                    @Parameter(name = "productId", description = "상품 ID")
+            }
+    )
     @ApiResponse(
             responseCode = "200",
             description = "상품에 옵션을 등록합니다."
@@ -54,7 +67,14 @@ public class ProductOptionController {
     }
 
     @DeleteMapping("/{productId}/options/{optionId}")
-    @Operation(summary = "상품 옵션 삭제", description = "상품에서 옵션을 삭제합니다.")
+    @Operation(
+            summary = "상품 옵션 삭제",
+            description = "상품에서 옵션을 삭제합니다.",
+            parameters = {
+                    @Parameter(name = "productId", description = "상품 ID"),
+                    @Parameter(name = "optionId", description = "옵션 ID")
+            }
+    )
     @ApiResponse(
             responseCode = "200",
             description = "상품에서 옵션을 삭제합니다."

--- a/src/main/java/gift/product/restapi/ProductOptionController.java
+++ b/src/main/java/gift/product/restapi/ProductOptionController.java
@@ -1,5 +1,6 @@
 package gift.product.restapi;
 
+import gift.advice.ErrorResponse;
 import gift.core.domain.product.ProductOptionService;
 import gift.product.restapi.dto.request.ProductOptionRegisterRequest;
 import gift.product.restapi.dto.response.ProductOptionResponse;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
@@ -55,9 +57,24 @@ public class ProductOptionController {
                     @Parameter(name = "productId", description = "상품 ID")
             }
     )
-    @ApiResponse(
-            responseCode = "200",
-            description = "상품에 옵션을 등록합니다."
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "상품에 옵션을 등록합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "상품에 옵션을 등록할 수 없습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "상품이 존재하지 않습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
     )
     public void registerOption(
             @PathVariable Long productId,
@@ -73,6 +90,31 @@ public class ProductOptionController {
             parameters = {
                     @Parameter(name = "productId", description = "상품 ID"),
                     @Parameter(name = "optionId", description = "옵션 ID")
+            }
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "상품에서 옵션을 삭제합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "상품에서 옵션을 삭제할 수 없습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "상품이 존재하지 않습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "옵션이 존재하지 않습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+
+                    )
             }
     )
     @ApiResponse(

--- a/src/main/java/gift/user/restapi/UserController.java
+++ b/src/main/java/gift/user/restapi/UserController.java
@@ -1,5 +1,6 @@
 package gift.user.restapi;
 
+import gift.advice.ErrorResponse;
 import gift.core.domain.user.User;
 import gift.core.domain.user.UserService;
 import gift.user.restapi.dto.response.UserResponse;
@@ -24,10 +25,19 @@ public class UserController {
 
     @GetMapping("/api/user/{id}")
     @Operation(summary = "사용자 조회", description = "사용자를 조회합니다.")
-    @ApiResponse(
-            responseCode = "200",
-            description = "사용자를 조회합니다.",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponse.class))
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "사용자를 조회합니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "사용자를 찾을 수 없습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
     )
     public UserResponse getUser(@PathVariable Long id) {
         User user = userService.getUserById(id);

--- a/src/main/java/gift/user/restapi/UserController.java
+++ b/src/main/java/gift/user/restapi/UserController.java
@@ -2,10 +2,18 @@ package gift.user.restapi;
 
 import gift.core.domain.user.User;
 import gift.core.domain.user.UserService;
+import gift.user.restapi.dto.response.UserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Tag(name = "사용자")
 public class UserController {
     private final UserService userService;
 
@@ -15,7 +23,15 @@ public class UserController {
     }
 
     @GetMapping("/api/user/{id}")
-    public User getUser(@PathVariable Long id) {
-        return userService.getUserById(id);
+    @Operation(summary = "사용자 조회", description = "사용자를 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "사용자를 조회합니다.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponse.class))
+    )
+    public UserResponse getUser(@PathVariable Long id) {
+        User user = userService.getUserById(id);
+
+        return UserResponse.of(user);
     }
 }

--- a/src/main/java/gift/user/restapi/dto/response/UserResponse.java
+++ b/src/main/java/gift/user/restapi/dto/response/UserResponse.java
@@ -1,0 +1,12 @@
+package gift.user.restapi.dto.response;
+
+import gift.core.domain.user.User;
+
+public record UserResponse(
+        Long id,
+        String name
+){
+    public static UserResponse of(User user) {
+        return new UserResponse(user.id(), user.name());
+    }
+}

--- a/src/main/java/gift/wishes/restapi/WishesController.java
+++ b/src/main/java/gift/wishes/restapi/WishesController.java
@@ -8,6 +8,7 @@ import gift.core.domain.wishes.WishesService;
 import gift.wishes.restapi.dto.request.AddWishRequest;
 import gift.wishes.restapi.dto.response.PagedWishResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -34,7 +35,14 @@ public class WishesController {
     }
 
     @GetMapping("/api/wishes")
-    @Operation(summary = "위시리스트 조회", description = "위시리스트를 조회합니다.")
+    @Operation(
+            summary = "위시리스트 조회",
+            description = "위시리스트를 조회합니다.",
+            parameters = {
+                    @Parameter(name = "page", description = "페이지 번호 (기본 값 : 0)"),
+                    @Parameter(name = "size", description = "페이지 크기 (기본 값 : 10)")
+            }
+    )
     @ApiResponse(
             responseCode = "200",
             description = "위시리스트를 조회합니다.",
@@ -60,7 +68,13 @@ public class WishesController {
     }
 
     @DeleteMapping("/api/wishes/{productId}")
-    @Operation(summary = "위시리스트 삭제", description = "위시리스트에서 상품을 삭제합니다.")
+    @Operation(
+            summary = "위시리스트 삭제",
+            description = "위시리스트에서 상품을 삭제합니다.",
+            parameters = {
+                    @Parameter(name = "productId", description = "상품 ID")
+            }
+    )
     @ApiResponse(
             responseCode = "200",
             description = "위시리스트에서 상품을 삭제합니다."

--- a/src/main/java/gift/wishes/restapi/WishesController.java
+++ b/src/main/java/gift/wishes/restapi/WishesController.java
@@ -7,6 +7,11 @@ import gift.core.domain.product.ProductService;
 import gift.core.domain.wishes.WishesService;
 import gift.wishes.restapi.dto.request.AddWishRequest;
 import gift.wishes.restapi.dto.response.PagedWishResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Pageable;
 
 @RestController
+@Tag(name = "위시리스트")
 public class WishesController {
     private final WishesService wishesService;
     private final ProductService productService;
@@ -28,6 +34,12 @@ public class WishesController {
     }
 
     @GetMapping("/api/wishes")
+    @Operation(summary = "위시리스트 조회", description = "위시리스트를 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "위시리스트를 조회합니다.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = PagedWishResponse.class))
+    )
     public PagedWishResponse getWishes(
             @LoggedInUser Long userId,
             @PageableDefault(size = 10) Pageable pageable
@@ -37,12 +49,22 @@ public class WishesController {
     }
 
     @PostMapping("/api/wishes")
+    @Operation(summary = "위시리스트 추가", description = "위시리스트에 상품을 추가합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "위시리스트에 상품을 추가합니다."
+    )
     public void addWish(@LoggedInUser Long userId, @RequestBody AddWishRequest request) {
         Product product = productService.get(request.productId());
         wishesService.addProductToWishes(userId, product);
     }
 
     @DeleteMapping("/api/wishes/{productId}")
+    @Operation(summary = "위시리스트 삭제", description = "위시리스트에서 상품을 삭제합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "위시리스트에서 상품을 삭제합니다."
+    )
     public void removeWish(@LoggedInUser Long userId, @PathVariable Long productId) {
         Product product = productService.get(productId);
         wishesService.removeProductFromWishes(userId, product);

--- a/src/main/java/gift/wishes/restapi/WishesController.java
+++ b/src/main/java/gift/wishes/restapi/WishesController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.web.PageableDefault;
@@ -58,9 +59,21 @@ public class WishesController {
 
     @PostMapping("/api/wishes")
     @Operation(summary = "위시리스트 추가", description = "위시리스트에 상품을 추가합니다.")
-    @ApiResponse(
-            responseCode = "200",
-            description = "위시리스트에 상품을 추가합니다."
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "위시리스트에 상품을 추가합니다."
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "상품을 찾을 수 없습니다."
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "위시리스트에 상품 추가 실패"
+                    )
+            }
     )
     public void addWish(@LoggedInUser Long userId, @RequestBody AddWishRequest request) {
         Product product = productService.get(request.productId());
@@ -75,9 +88,17 @@ public class WishesController {
                     @Parameter(name = "productId", description = "상품 ID")
             }
     )
-    @ApiResponse(
-            responseCode = "200",
-            description = "위시리스트에서 상품을 삭제합니다."
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "위시리스트에서 상품을 삭제합니다."
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "위시리스트에서 상품을 찾을 수 없습니다."
+                    )
+            }
     )
     public void removeWish(@LoggedInUser Long userId, @PathVariable Long productId) {
         Product product = productService.get(productId);


### PR DESCRIPTION
* 5주차 3단계 과제입니다!

이번 3단계 과제 요구사항에는 swagger를 사용하여 문서화를 해보았습니다!
기존 개인 프로젝트나 다른 활동에서 개발을 할 때에도 직접 문서를 하나하나 작성하거나 말로 전달하는데 한계를 느껴 api 문서화에 관한 스택이 필요함을 느끼고 있었습니다. 이때 Swagger 와 RestDocs 의 장단점을 보며 여러가지 고민을 했었는데, API 스펙에 관한 문서는 개발 단계에서 변동성이 크고, 또 기존 코드와는 다른 관심사라고 생각하여 제품 코드를 해치는게 매우 부적절해보여 RestDocs를 적용하게 되었습니다. 테스트를 통해 어느정도 검증된 API가 명시된다는 점도 꽤 장점이라고 생각했습니다.
그러나 restdocs 또한 mockmvc에 대한 이해나 api 문서화에 지나치게 많은 시간을 투입하게 하는 단점을 무시할 수 없고,
테스트를 통해 이루어지는 api 문서화와 다른 코드 검증용 테스트 코드가 같은 위치에 있는게 부적합하다고 생각하였습니다. (커버리지 테스트 등에서 별도 설정에 시간을 낭비하는 문제점이 있다고 생각했습니다)
이런 문제점 자체는 사용하는 사람들도 어느정도 인지는 하고 있는 것 같았으나, 오픈소스로 이러한 문제를 효과적으로 해결해주는 유명한 프로젝트는 잘 보이지 않는 것 같아 처음부터 프로젝트를 구성할 때 멀티모듈로 구성하고, 도큐먼트 모듈을 분리하여 직접 만든 코틀린 restdocs dsl로 도큐먼트 작업을 하는 등으로 이런 부분들을 보완해서 개발하고 있었습니다. 혹시 다른 좋은 방법이 있는지도 궁금합니다!

앞선 질문의 연장선으로, 이번 주차 과제에서는 호기심에 사용해보지 않은 Swagger 를 적용하게 되었는데, 여전히 이런 제품 코드를 보기 힘들게 만드는 문제가 많이 발생하는 것 같아 이런 문제를 해결 할 수 있는 좋은 방법이 궁금합니다. 컨트롤러에서 API 인터페이스를 분리하여 해당 인터페이스에 api 스펙 관련 어노테이션을 몰아주는 방법도 보긴 했지만 결국 핵심 모듈 안에 문서화 코드가 같이 담긴다는 점과, 인터페이스로의 역할을 잘 못하는 것 같다는 부분이 아쉽다는 생각이 들었습니다.

저번 주차 피드백 관련해서도 궁금했던 점이 있었는데,
더티 체크를 통한 업데이트를 추천해주셨던걸 보았습니다.
저 또한 더티 체크를 통한 업데이트 방법에 대해서 알고는 있었지만, 이런 방법이 편하긴 하지만 실제 상용 코드에 포함되기에는 조금 부적절한 부분이 있지 않나 생각하여 사용을 꺼리게 되었습니다.
제가 그렇게 생각했던 이유는 우선 첫째로 동등한 Entity 객체더라도 Jpa 등을 통해 불러온 프록시 객체를 통해서만 동작하므로
사용이 제한적이고 사이드 이펙트가 발생했을 때 찾기 힘들지 않을까라는 생각이었습니다. 객체의 값을 변경할 때는 자체 setter 등의 modifier 를 이용하는 것이 조금 더 명시적으로 보이기는 하지만, repository 클래스를 통해서도 어느정도 해결할 수 있는 부분이라고 생각했습니다.
둘째로 규모에 따라 레이어드 아키텍처나 클린 아키텍처 파생 아키텍처를 기용하는 곳이 많은데, 이렇게 코드가 분리될 수 있다는 것을 상정했을 때, 서비스 레이어에서는 구조 변경에 최대한 잘 대응할 수 있도록 특정 기술에 의존적인 코드를 최대한 제거하고 느슨한 결합을 통해 개발을 하는 것이 유리하다고 생각했습니다. 그러다보니 더티체크 업데이트 사용을 항상 기피해왔는데, 사용했을 때의 이점이나 좋은 사용 예시가 궁금합니다! 