### PR TITLE
강원대 BE_이강욱_5주차 과제(3단계)

### DIFF
--- a/src/main/java/gift/auth/EmailAuthService.java
+++ b/src/main/java/gift/auth/EmailAuthService.java
@@ -21,7 +21,7 @@ public class EmailAuthService implements AuthService {
 
     @Override
     public String getLoginUrl() {
-        return ""; // 이메일 로그인은 별도 URL이 필요 없음
+        return "";
     }
 
     @Override
@@ -33,7 +33,7 @@ public class EmailAuthService implements AuthService {
         User user = userRepository.findByEmail(userLoginDto.getEmail())
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
 
-        if (!user.isPasswordCorrect(userLoginDto.getPassword())) {
+        if (user.isPasswordIncorrect(userLoginDto.getPassword())) {
             throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
         }
 

--- a/src/main/java/gift/client/KakaoApi.java
+++ b/src/main/java/gift/client/KakaoApi.java
@@ -1,0 +1,10 @@
+package gift.client;
+
+import gift.entity.Order;
+import gift.dto.KakaoUserResponse;
+
+public interface KakaoApi {
+    String getAccessToken(String authorizationCode);
+    KakaoUserResponse getUserInfo(String accessToken);
+    void sendMessageToMe(String kakaoAccessToken, Order order);
+}

--- a/src/main/java/gift/client/KakaoApiClient.java
+++ b/src/main/java/gift/client/KakaoApiClient.java
@@ -24,14 +24,16 @@ import java.io.IOException;
 import java.time.Duration;
 
 @Component
-public class KakaoApiClient {
+public class KakaoApiClient implements KakaoApi {
 
     private final KakaoProperties kakaoProperties;
     private final WebClient webClient;
+    private final ObjectMapper objectMapper;
 
     public KakaoApiClient(KakaoProperties kakaoProperties, WebClient.Builder webClientBuilder) {
         this.kakaoProperties = kakaoProperties;
         this.webClient = createWebClient(webClientBuilder);
+        this.objectMapper = new ObjectMapper();
     }
 
     private WebClient createWebClient(WebClient.Builder webClientBuilder) {
@@ -45,6 +47,7 @@ public class KakaoApiClient {
                 .build();
     }
 
+    @Override
     public String getAccessToken(String authorizationCode) {
         String body = UriComponentsBuilder.newInstance()
                 .queryParam("grant_type", "authorization_code")
@@ -74,6 +77,7 @@ public class KakaoApiClient {
                 .block();
     }
 
+    @Override
     public KakaoUserResponse getUserInfo(String accessToken) {
         return webClient.get()
                 .uri(kakaoProperties.getInfoUrl())
@@ -95,6 +99,7 @@ public class KakaoApiClient {
                 .block();
     }
 
+    @Override
     public void sendMessageToMe(String kakaoAccessToken, Order order) {
         String templateObject = buildTemplateObject(order);
 
@@ -123,7 +128,6 @@ public class KakaoApiClient {
 
     private JsonNode parseJson(String body) {
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
             return objectMapper.readTree(body);
         } catch (IOException e) {
             throw new BusinessException(ErrorCode.KAKAO_AUTH_FAILED, "JSON 파싱 오류: " + e.getMessage());

--- a/src/main/java/gift/client/KakaoApiClient.java
+++ b/src/main/java/gift/client/KakaoApiClient.java
@@ -36,8 +36,8 @@ public class KakaoApiClient {
 
     private WebClient createWebClient(WebClient.Builder webClientBuilder) {
         HttpClient httpClient = HttpClient.create()
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
-                .responseTimeout(Duration.ofSeconds(5));
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, kakaoProperties.getConnectTimeoutMillis())
+                .responseTimeout(Duration.ofSeconds(kakaoProperties.getResponseTimeoutSeconds()));
 
         return webClientBuilder
                 .clientConnector(new ReactorClientHttpConnector(httpClient))

--- a/src/main/java/gift/config/KakaoProperties.java
+++ b/src/main/java/gift/config/KakaoProperties.java
@@ -11,16 +11,20 @@ public class KakaoProperties {
     private final String authUrl;
     private final String tokenUrl;
     private final String infoUrl;
-    private final String messageUrl; // 메시지 전송 API URL 추가
+    private final String messageUrl;
+    private final int connectTimeoutMillis;
+    private final int responseTimeoutSeconds;
 
     @ConstructorBinding
-    public KakaoProperties(String clientId, String redirectUri, String authUrl, String tokenUrl, String infoUrl, String messageUrl) {
+    public KakaoProperties(String clientId, String redirectUri, String authUrl, String tokenUrl, String infoUrl, String messageUrl, int connectTimeoutMillis, int responseTimeoutSeconds) {
         this.clientId = clientId;
         this.redirectUri = redirectUri;
         this.authUrl = authUrl;
         this.tokenUrl = tokenUrl;
         this.infoUrl = infoUrl;
         this.messageUrl = messageUrl;
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        this.responseTimeoutSeconds = responseTimeoutSeconds;
     }
 
     public String getClientId() {
@@ -45,5 +49,13 @@ public class KakaoProperties {
 
     public String getMessageUrl() {
         return messageUrl;
+    }
+
+    public int getConnectTimeoutMillis() {
+        return connectTimeoutMillis;
+    }
+
+    public int getResponseTimeoutSeconds() {
+        return responseTimeoutSeconds;
     }
 }

--- a/src/main/java/gift/entity/User.java
+++ b/src/main/java/gift/entity/User.java
@@ -62,6 +62,10 @@ public class User {
         return this.password != null && this.password.equals(password);
     }
 
+    public boolean isPasswordIncorrect(String password) {
+        return !isPasswordCorrect(password);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/gift/service/OrderService.java
+++ b/src/main/java/gift/service/OrderService.java
@@ -1,6 +1,6 @@
 package gift.service;
 
-import gift.client.KakaoApiClient;
+import gift.client.KakaoApi;
 import gift.dto.OrderRequestDto;
 import gift.dto.OrderResponseDto;
 import gift.entity.Order;
@@ -26,17 +26,17 @@ public class OrderService {
     private final ProductOptionRepository productOptionRepository;
     private final UserRepository userRepository;
     private final WishRepository wishRepository;
-    private final KakaoApiClient kakaoApiClient;
+    private final KakaoApi kakaoApi;
     private final TokenService tokenService;
 
     public OrderService(OrderRepository orderRepository, ProductOptionRepository productOptionRepository,
                         UserRepository userRepository, WishRepository wishRepository,
-                        KakaoApiClient kakaoApiClient, TokenService tokenService) {
+                        KakaoApi kakaoApi, TokenService tokenService) {
         this.orderRepository = orderRepository;
         this.productOptionRepository = productOptionRepository;
         this.userRepository = userRepository;
         this.wishRepository = wishRepository;
-        this.kakaoApiClient = kakaoApiClient;
+        this.kakaoApi = kakaoApi;
         this.tokenService = tokenService;
     }
 
@@ -96,6 +96,6 @@ public class OrderService {
     }
 
     private void sendOrderConfirmationMessage(String kakaoAccessToken, Order order) {
-        kakaoApiClient.sendMessageToMe(kakaoAccessToken, order);
+        kakaoApi.sendMessageToMe(kakaoAccessToken, order);
     }
 }

--- a/src/main/java/gift/service/OrderService.java
+++ b/src/main/java/gift/service/OrderService.java
@@ -12,6 +12,7 @@ import gift.repository.OrderRepository;
 import gift.repository.ProductOptionRepository;
 import gift.repository.UserRepository;
 import gift.repository.WishRepository;
+import gift.value.Token;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,10 +42,10 @@ public class OrderService {
 
     @Transactional
     public OrderResponseDto createOrder(String jwtToken, String kakaoAccessToken, OrderRequestDto requestDto) {
-        String jwt = jwtToken.replace("Bearer ", "");
-        String kakaoToken = kakaoAccessToken.replace("Bearer ", "");
+        Token jwt = new Token(jwtToken);
+        Token kakaoToken = new Token(kakaoAccessToken);
 
-        Map<String, String> userInfo = tokenService.extractUserInfo(jwt);
+        Map<String, String> userInfo = tokenService.extractUserInfo(jwt.getToken());
         String userId = userInfo.get("id");
 
         User user = findUserById(userId);
@@ -58,7 +59,7 @@ public class OrderService {
 
         removeWish(user, productOption);
 
-        sendOrderConfirmationMessage(kakaoToken, order);
+        sendOrderConfirmationMessage(kakaoToken.getToken(), order);
 
         return new OrderResponseDto(order.getId(), productOption.getId(), order.getQuantity(), order.getOrderDateTime(), order.getMessage());
     }

--- a/src/main/java/gift/value/Token.java
+++ b/src/main/java/gift/value/Token.java
@@ -1,0 +1,13 @@
+package gift.value;
+
+public class Token {
+    private final String token;
+
+    public Token(String token) {
+        this.token = token.replace("Bearer ", "");
+    }
+
+    public String getToken() {
+        return token;
+    }
+}

--- a/src/test/java/gift/auth/KakaoAuthServiceTest.java
+++ b/src/test/java/gift/auth/KakaoAuthServiceTest.java
@@ -8,7 +8,7 @@ import gift.entity.User;
 import gift.repository.KakaoUserRepository;
 import gift.repository.UserRepository;
 import gift.service.TokenService;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,10 +16,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 
 @SpringBootTest
@@ -31,10 +29,10 @@ public class KakaoAuthServiceTest {
     @MockBean
     private KakaoApiClient kakaoApiClient;
 
-    @MockBean
+    @Autowired
     private UserRepository userRepository;
 
-    @MockBean
+    @Autowired
     private KakaoUserRepository kakaoUserRepository;
 
     @MockBean
@@ -43,18 +41,10 @@ public class KakaoAuthServiceTest {
     @Autowired
     private KakaoProperties kakaoProperties;
 
-    private KakaoUserResponse kakaoUserResponse;
-    private User user;
-    private KakaoUser kakaoUser;
-
-    @BeforeEach
-    public void setup() {
-        kakaoUserResponse = new KakaoUserResponse(12345L, new KakaoUserResponse.Properties("testNickname"));
-
-        user = new User(1L, "test@example.com", "password");
-
-        kakaoUser = new KakaoUser(kakaoUserResponse.getId(), kakaoUserResponse.getProperties().getNickname(), user);
-        user.setKakaoUser(kakaoUser);
+    @AfterEach
+    public void tearDown() {
+        kakaoUserRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test
@@ -66,12 +56,10 @@ public class KakaoAuthServiceTest {
 
     @Test
     public void 카카오_콜백_처리_성공() {
+        KakaoUserResponse kakaoUserResponse = new KakaoUserResponse(12345L, new KakaoUserResponse.Properties("testNickname"));
+
         Mockito.when(kakaoApiClient.getAccessToken(anyString())).thenReturn("mockAccessToken");
         Mockito.when(kakaoApiClient.getUserInfo(anyString())).thenReturn(kakaoUserResponse);
-
-        Mockito.when(kakaoUserRepository.findByKakaoId(anyLong())).thenReturn(Optional.empty());
-        Mockito.when(userRepository.save(Mockito.any(User.class))).thenReturn(user);
-        Mockito.when(kakaoUserRepository.save(Mockito.any(KakaoUser.class))).thenReturn(kakaoUser);
         Mockito.when(tokenService.generateToken(anyString(), anyString())).thenReturn("mockJwtToken");
 
         Map<String, String> tokens = kakaoAuthService.handleCallback("mockAuthorizationCode");
@@ -79,10 +67,17 @@ public class KakaoAuthServiceTest {
         assertNotNull(tokens);
         assertEquals("mockAccessToken", tokens.get("kakaoAccessToken"));
         assertEquals("mockJwtToken", tokens.get("jwtToken"));
+
+        KakaoUser kakaoUser = kakaoUserRepository.findByKakaoId(12345L).orElse(null);
+        assertNotNull(kakaoUser);
+        assertEquals("testNickname", kakaoUser.getNickname());
     }
 
     @Test
     public void 토큰_생성_성공() {
+        User user = new User("test@example.com", "password");
+        userRepository.save(user);
+
         Mockito.when(tokenService.generateToken(anyString(), anyString())).thenReturn("mockToken");
 
         String token = kakaoAuthService.generateToken(user);


### PR DESCRIPTION
# 질문에 대한 답변

> *비동기 패러다임과 함께 webClient를 사용할게 아니라면 굳이 webClient를 사용하면서 써야하나 싶어보이네요!*
> 
> 
> *webClient를 사용한, 사용해야한 이유가 있나요?*

> 

이부분은 1단계 피드백에서 멘토님이

> restTemplate말고 다른 통신 구현체도 있으니 찾아서 활용해보시면 좋을것 같습니다.
> 

라고 하셔서, 한번 찾아보니까 `WebClient` 에 대해 나와서 적용했던 부분이였습니다.

### WebClient와 RestTemplate


`RestTemplate` : Spring 3.0에서 도입된 HTTP 클라이언트. 동기 방식으로 동작한다.


#### **장점**

- **간편함**: 사용하기 매우 간편하며, 대부분의 기본적인 HTTP 통신을 쉽게 구현할 수 있다.
- **오래됨**: 오랜 기간 사용되었기 때문에 안정적이며, 많은 정보가 있다.

#### **단점**

- **동기식**: 모든 요청이 블로킹 방식으로 처리되기 때문에, I/O 작업이 완료될 때까지 스레드가 대기해야 한다.(동기 방식)


`WebClient` : Spring 5.0에서 도입된 비동기 및 반응형 HTTP 클라이언트. 비동기 방식으로 동작한다.


### **특징**

- **비동기식**: 비동기 방식으로 요청을 처리하기 때문에, 높은 동시성을 요구하는 애플리케이션에 적합하다.
- **유연성**: `WebClient`는 동기 및 비동기 방식 모두를 지원하며, 다양한 프로토콜과 데이터 포맷을 처리할 수 있다.

---

물론 지금 상황에서 비동기 처리가 필요하지는 않지만, 그냥 이런게 있구나 하고 여러가지를 이용해보려고 한 부분도 있는데, (더 현대식이기도 하고) 솔직히 말하자면 사용한것에 대해 큰 이유가 있는 것은 아닙니다..!

그냥 동기, 비동기 처리 둘 다 가능하기도 하고, 더 최신 기술이기도 해서 사용을 해본 부분이였습니다!

## exception이 다른데..

> *[질문] validate할때 발생하는 exception과 option에서 양을 감소시킬때 발생하는 exception이 다른데요.*
> 
> 
> *달라야 하는게 맞는상황인가요?*
> 
> ![image](https://github.com/user-attachments/assets/3566150c-72a8-4d1d-9956-74659f38fe77)
> 

```java
private void validateProductOptionQuantity(ProductOption productOption, int requestedQuantity) {
    if (productOption.getQuantity() < requestedQuantity) {
        throw new BusinessException(ErrorCode.INSUFFICIENT_QUANTITY);
    }
}
```

이게 validate할 때고 

```java
public void decreaseQuantity(int amount) {
    if (amount <= MIN_QUANTITY) {
        throw new BusinessException(ErrorCode.INVALID_DECREASE_QUANTITY);
    }
    int decreaseQuantity = this.quantity - amount;
    if (decreaseQuantity < MIN_QUANTITY) {
        throw new BusinessException(ErrorCode.INSUFFICIENT_QUANTITY);
    }
    this.quantity = decreaseQuantity;
}
```

이때가 감소시킬때.. 인데 

제가 질문을 잘 이해한 것인지는 모르겠으나, 

`throw new BusinessException(ErrorCode.INVALID_DECREASE_QUANTITY);` 이 부분을 말씀하시는 것일까요?

`validateProductOptionQuantity` 에서는 감소되었을 때 수량이 올바른지(”남은 수량이 부족합니다”) 를 체크하는것이고, 

엔티티 내에서 나오는 부분은 감소량 자체의 숫자가 올바른지(”감소 수량은 0보다 커야합니다”) 체크하는 것이여서 다른 것인데

제가 질문에 대해 제대로 이해한 것이 맞을까요?

# 피드백을 반영하며 생긴 의문점

## ObjectMapper 에 대한 피드백을 반영하던 중…

> JSON 포맷에 맞게 클래스를 설계하고 → objectMapper을 이용해 JSON 문자열로 직렬화 하는 방식!
> 

대로 진행해 보았습니다…

그래서 `KakaoMessageTemplate` 을 형식에 맞게 만들고(형식이 틀리지 않은 것 같다고 생각합니다..!)

```java
package gift.dto;

import com.fasterxml.jackson.annotation.JsonProperty;

public class KakaoMessageTemplate {

    @JsonProperty("object_type")
    private String object_type;
    private String text;
    private Link link;

    public KakaoMessageTemplate(String object_type, String text, Link link) {
        this.object_type = object_type;
        this.text = text;
        this.link = link;
    }

    public static class Link {
        @JsonProperty("web_url")
        private String web_url;
        @JsonProperty("mobile_web_url")
        private String mobile_web_url;

        public Link(String webUrl, String mobileWebUrl) {
            this.web_url = webUrl;
            this.mobile_web_url = mobileWebUrl;
        }
    }
}
```

구현체에서 이를 이용하도록 했습니다!

```java
private String buildTemplateObject(Order order) {
    KakaoMessageTemplate.Link link = new KakaoMessageTemplate.Link("http://localhost:8080", "http://localhost:8080");
    KakaoMessageTemplate template = new KakaoMessageTemplate(
            "text",
            String.format("상품 : %s\\n수량 : %d\\n%s",
                    order.getProductOption().getProduct().getName().getValue(),
                    order.getQuantity(),
                    order.getMessage()),
            link);

    try {
        return objectMapper.writeValueAsString(template);
    } catch (IOException e) {
        throw new BusinessException(ErrorCode.KAKAO_MESSAGE_SEND_FAILED, "JSON 직렬화 오류: " + e.getMessage());
    }
}
```

정말 기존과 동일하게 진행했는데, 위 형식으로 수정을 하니까 또 똑같은 에러가 뜹니다…

> 카카오 메시지 전송을 실패했습니다. HTTP 오류: 400 BAD_REQUEST - {"msg":"failed to parse parameter. name=template_object, stringToParse=-, paramString=-, paramStringAlias=null","code":-2}
> 

그리고 이 코드가 기존 형식입니다.

```java
private String buildTemplateObject(Order order) {
    return String.format("{\"object_type\":\"text\",\"text\":\"상품 : %s\\n수량 : %d\\n%s\",\"link\":{\"web_url\":\"http://localhost:8080\",\"mobile_web_url\":\"http://localhost:8080\"}}",
            order.getProductOption().getProduct().getName().getValue(), order.getQuantity(), order.getMessage());
}
```

이게 template_object 파라미터를 제대로 파싱하지 못해서 나는 에러인데, 기존 방식에서 형식은 정말 동일하고 방법만 멘토님이 주신 피드백대로 바꿨다고 생각했는데, 저 에러가 뜹니다…

제가 수정하는 과정에서 약간 달라진 것일까요? 저런 식으로 하는게 아닌건가요? 

알려주시면 감사하겠습니다! 

## 인터페이스에 의존?

> 구현체에 의존하지 않고 interface에 의존해보시면 좋을것 같습니다.
> 

> service의 입장에서 바라보았을때 kakaoApi를 호출했다가 중요하지 어떻게 이루어진 구현체에게 호출했다는 중요하지 않습니다.
> 

> service 코드에 작성된 코드들은 모두 동일한 수준의 추상화 수준을 이루는 것이 좋습니다
> 

`KakaoApiClient` 라는 구체적인 구현체가 아닌, 인터페이스를 사용하여 인터페이스에 의존하는것이 좋다는 말씀이신 것 같다. 

그래서 코드의 추상화 수준을 통일시키는 것이 좋다..! 이 말인것 같은데 이렇게 진행하면 되는 것일까?

1. 인터페이스 정의 : `KakaoApiClient` 의 기능을 정의하는 인터페이스를 만든다. 
2. 구현 클래스 구현 : `KakaoApiClient` 클래스가 이 인터페이스를 구현하도록 한다. 
3. 서비스에서 인터페이스를 이용 : `OrderService` 에서 `KakaoApiClient` 대신 이 인터페이스를 사용하도록 수정한다.

---

주신 피드백에 대해 제가 이 방법으로 진행하여 지금 코드가 되었는데, 제가 잘 이해한 것이 맞을까요?! 

아무튼 이와 같이 진행해보았습니다..!

- [x]  토큰처리 값 객체로
- [x]  Interface에 의존
- [x]  테스트 mock과 setUp
- [x]  Timeout 값도 프로퍼티에 넣기
- [x]  부정표현 대신 네이밍을 바꿔
- [ ]  objectMapper을 쓰는 방법

그리고 저번 피드백에서 제가 노션 블록 링크를 걸었던걸 그대로 올려서 안보이는 것인데, 

[[7/26](https://www.notion.so/7-26-772310dc56084dd092b1fee5ae0cf20c?pvs=21)](https://www.notion.so/7-26-772310dc56084dd092b1fee5ae0cf20c?pvs=21) << 여기에 정리하면서 진행한 것이였습니다..! 

노션까지 보실 필요는 없지만.. 저번에 안들어가져서 혹시 궁금해하실까봐 링크 달아놓겠습니다 ㅎㅎ


3단계는 이미 완료되어있어서 따로 추가한 것은 없고 
4단계에 대해서는 개념공부 후 시간이 있다면 적용을 해볼 예정입니다! (제출을 일단 해야해서 PR을 날렸습니다 ㅎㅎ)

일단 그래서 이번에는 Step2 에 대한 피드백만 진행해 보았습니다! 

바쁘실텐데 늘 꾸준히 피드백 많이 주셔서 정말 감사드립니다...🥹 덕분에 정말 많은 것을 얻어가고 있는 것 같습니다..!
고생 정말 많으십니다 멘토님 감사합니다!