### PR TITLE
부산대 BE_박혜연 5주차 과제 (2단계)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 ### step 1
 1. 카카오 인가코드 받기
 2. 카카오 토큰 받기 및 로그인(토큰 발급)
+
+### step 2
+1. kakaoToken 저장하기(entity, repository)
+2. kakao 메시지 보내기
+3. option 수량 차감
+4. wishList에 존재하면 삭제하기
+5. test 코드 작성

--- a/src/main/java/gift/administrator/category/Category.java
+++ b/src/main/java/gift/administrator/category/Category.java
@@ -74,10 +74,6 @@ public class Category {
         return description;
     }
 
-    public List<Product> getProducts() {
-        return products;
-    }
-
     public void addProducts(Product product) {
         this.products.add(product);
         product.setCategory(this);
@@ -86,11 +82,5 @@ public class Category {
     public void removeProduct(Product product) {
         products.remove(product);
         product.setCategory(null);
-    }
-
-    public void removeProducts(List<Product> products) {
-        for(Product product : new ArrayList<>(products)){
-            removeProduct(product);
-        }
     }
 }

--- a/src/main/java/gift/administrator/category/Category.java
+++ b/src/main/java/gift/administrator/category/Category.java
@@ -28,15 +28,15 @@ public class Category {
     public Category() {
     }
 
-    public Category(String name, String color, String imageUrl, String description) {
+    public Category(Long id, String name, String color, String imageUrl, String description) {
+        this.id = id;
         this.name = name;
         this.color = color;
         this.imageUrl = imageUrl;
         this.description = description;
     }
 
-    public Category(Long id, String name, String color, String imageUrl, String description) {
-        this.id = id;
+    public Category(String name, String color, String imageUrl, String description) {
         this.name = name;
         this.color = color;
         this.imageUrl = imageUrl;
@@ -52,10 +52,6 @@ public class Category {
 
     public Long getId() {
         return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public String getName() {

--- a/src/main/java/gift/administrator/category/CategoryApiController.java
+++ b/src/main/java/gift/administrator/category/CategoryApiController.java
@@ -44,9 +44,8 @@ public class CategoryApiController {
     @PutMapping("/{id}")
     public ResponseEntity<CategoryDTO> updateCategory(@PathVariable("id") Long id,
         @Valid @RequestBody CategoryDTO categoryDTO) {
-        categoryDTO.setId(id);
-        categoryService.existsByNameAndId(categoryDTO.getName(), categoryDTO.getId());
-        CategoryDTO result = categoryService.updateCategory(categoryDTO);
+        categoryService.existsByNameAndId(categoryDTO.getName(), id);
+        CategoryDTO result = categoryService.updateCategory(categoryDTO, id);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/gift/administrator/category/CategoryDTO.java
+++ b/src/main/java/gift/administrator/category/CategoryDTO.java
@@ -37,10 +37,6 @@ public class CategoryDTO {
         return id;
     }
 
-    public void setId(long id) {
-        this.id = id;
-    }
-
     public String getName() {
         return name;
     }

--- a/src/main/java/gift/administrator/category/CategoryRepository.java
+++ b/src/main/java/gift/administrator/category/CategoryRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    Boolean existsByName(String name);
+    boolean existsByName(String name);
 
-    Boolean existsByNameAndIdNot(String name, long id);
+    boolean existsByNameAndIdNot(String name, long id);
 }

--- a/src/main/java/gift/administrator/category/CategoryService.java
+++ b/src/main/java/gift/administrator/category/CategoryService.java
@@ -37,9 +37,9 @@ public class CategoryService {
             .orElseThrow(() -> new NotFoundIdException("카테고리 아이디를 찾을 수 없습니다."));
     }
 
-    public CategoryDTO updateCategory(CategoryDTO categoryDTO) {
-        Category category = findByCategoryId(categoryDTO.getId());
-        if (categoryRepository.existsByNameAndIdNot(categoryDTO.getName(), categoryDTO.getId())) {
+    public CategoryDTO updateCategory(CategoryDTO categoryDTO, long categoryId) {
+        Category category = findByCategoryId(categoryId);
+        if (categoryRepository.existsByNameAndIdNot(categoryDTO.getName(), categoryId)) {
             throw new IllegalArgumentException("존재하는 이름입니다.");
         }
         category.update(categoryDTO.getName(), categoryDTO.getColor(), categoryDTO.getImageUrl(),
@@ -54,7 +54,7 @@ public class CategoryService {
         categoryRepository.deleteById(id);
     }
 
-    public boolean existsByName(String name) {
+    private boolean existsByName(String name) {
         return categoryRepository.existsByName(name);
     }
 
@@ -64,8 +64,7 @@ public class CategoryService {
         }
     }
 
-    public void existsByNameAndId(String name, long id)
-        throws NotFoundIdException {
+    public void existsByNameAndId(String name, long id) {
         if (existsByName(name) && !Objects.equals(getCategoryById(id).getName(), name)) {
             throw new IllegalArgumentException("존재하는 이름입니다.");
         }

--- a/src/main/java/gift/administrator/option/Option.java
+++ b/src/main/java/gift/administrator/option/Option.java
@@ -1,8 +1,6 @@
 package gift.administrator.option;
 
 import gift.administrator.product.Product;
-import gift.users.wishlist.WishList;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,9 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 public class Option {
@@ -28,8 +23,6 @@ public class Option {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
-    @OneToMany(mappedBy = "option", orphanRemoval = true, cascade = CascadeType.ALL)
-    private List<WishList> wishes = new ArrayList<>();
 
     public Option() {
     }
@@ -74,15 +67,5 @@ public class Option {
 
     public void setProduct(Product product) {
         this.product = product;
-    }
-
-    public void addWishList(WishList wishList) {
-        this.wishes.add(wishList);
-        wishList.setOption(this);
-    }
-
-    public void removeWishList(WishList wishList) {
-        wishes.remove(wishList);
-        wishList.setOption(null);
     }
 }

--- a/src/main/java/gift/administrator/option/OptionDTO.java
+++ b/src/main/java/gift/administrator/option/OptionDTO.java
@@ -35,10 +35,6 @@ public class OptionDTO {
         this.productId = productId;
     }
 
-    public void subtract(int quantity) {
-        this.quantity -= quantity;
-    }
-
     public Long getId(){
         return id;
     }

--- a/src/main/java/gift/administrator/option/OptionRepository.java
+++ b/src/main/java/gift/administrator/option/OptionRepository.java
@@ -11,5 +11,5 @@ public interface OptionRepository extends JpaRepository<Option, Long> {
 
     boolean existsByNameAndProductIdAndIdNot(String name, long productId, long optionId);
 
-    int countAllByProductId(long productId);
+    int countAllByProductId(Long productId);
 }

--- a/src/main/java/gift/administrator/option/OptionService.java
+++ b/src/main/java/gift/administrator/option/OptionService.java
@@ -1,6 +1,5 @@
 package gift.administrator.option;
 
-import gift.administrator.product.Product;
 import gift.error.NotFoundIdException;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -54,21 +53,26 @@ public class OptionService {
 
     private Option findByOptionId(long optionId) {
         return optionRepository.findById(optionId)
-            .orElseThrow(() -> new NotFoundIdException("아이디를 찾을 수 없습니다."));
+            .orElseThrow(() -> new NotFoundIdException("옵션 아이디를 찾을 수 없습니다."));
+    }
+
+    public void subtractOptionQuantityErrorIfNotPossible(long optionId, int quantity){
+        Option option = findByOptionId(optionId);
+        if (option.getQuantity() < quantity) {
+            throw new IllegalArgumentException("옵션의 재고가 부족합니다.");
+        }
     }
 
     public Option subtractOptionQuantity(long optionId, int quantity) {
         Option option = findByOptionId(optionId);
-        if (option.getQuantity() < quantity) {
-            throw new IllegalArgumentException("옵션의 수량이 부족합니다.");
-        }
         option.subtract(quantity);
+        optionRepository.save(option);
         return option;
     }
 
     public void deleteOptionByOptionId(long optionId) {
         if (!optionRepository.existsById(optionId)) {
-            throw new IllegalArgumentException("없는 아이디입니다.");
+            throw new IllegalArgumentException("옵션 없는 아이디입니다.");
         }
         Option option = findByOptionId(optionId);
         option.getProduct().removeOption(option);

--- a/src/main/java/gift/administrator/option/OptionService.java
+++ b/src/main/java/gift/administrator/option/OptionService.java
@@ -66,11 +66,6 @@ public class OptionService {
         return option;
     }
 
-    public void deleteAllWhenUpdatingProduct(List<Option> options, Product product) {
-        product.getOptions().removeAll(options);
-        optionRepository.deleteAll(options);
-    }
-
     public void deleteOptionByOptionId(long optionId) {
         if (!optionRepository.existsById(optionId)) {
             throw new IllegalArgumentException("없는 아이디입니다.");

--- a/src/main/java/gift/administrator/option/OptionService.java
+++ b/src/main/java/gift/administrator/option/OptionService.java
@@ -37,7 +37,7 @@ public class OptionService {
     }
 
     public int countAllOptionsByProductIdFromOptionId(long optionId) {
-        long productId = findOptionById(optionId).getProductId();
+        Long productId = findOptionById(optionId).getProductId();
         return optionRepository.countAllByProductId(productId);
     }
 
@@ -71,9 +71,6 @@ public class OptionService {
     }
 
     public void deleteOptionByOptionId(long optionId) {
-        if (!optionRepository.existsById(optionId)) {
-            throw new IllegalArgumentException("옵션 없는 아이디입니다.");
-        }
         Option option = findByOptionId(optionId);
         option.getProduct().removeOption(option);
         optionRepository.deleteById(option.getId());

--- a/src/main/java/gift/administrator/product/Product.java
+++ b/src/main/java/gift/administrator/product/Product.java
@@ -2,7 +2,6 @@ package gift.administrator.product;
 
 import gift.administrator.category.Category;
 import gift.administrator.option.Option;
-import gift.users.wishlist.WishList;
 import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,8 +18,6 @@ public class Product {
     private String name;
     @Column(nullable = false)
     private String imageUrl;
-    @OneToMany(mappedBy = "product")
-    private List<WishList> wishes = new ArrayList<>();
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
@@ -70,10 +67,6 @@ public class Product {
         return imageUrl;
     }
 
-    public List<WishList> getWishes() {
-        return wishes;
-    }
-
     public Category getCategory() {
         return category;
     }
@@ -84,16 +77,6 @@ public class Product {
 
     public void setOption(List<Option> options){
         this.options = options;
-    }
-
-    public void addWishList(WishList wishList) {
-        wishes.add(wishList);
-        wishList.setProduct(this);
-    }
-
-    public void removeWishList(WishList wishList) {
-        wishes.remove(wishList);
-        wishList.setProduct(null);
     }
 
     public void addOption(Option option) {

--- a/src/main/java/gift/administrator/product/Product.java
+++ b/src/main/java/gift/administrator/product/Product.java
@@ -27,7 +27,9 @@ public class Product {
     public Product() {
     }
 
-    public Product(String name, int price, String imageUrl, Category category, List<Option> options) {
+    public Product(Long id, String name, int price, String imageUrl, Category category,
+        List<Option> options) {
+        this.id = id;
         this.price = price;
         this.name = name;
         this.imageUrl = imageUrl;
@@ -35,8 +37,8 @@ public class Product {
         this.options = options;
     }
 
-    public Product(Long id, String name, int price, String imageUrl, Category category, List<Option> options) {
-        this.id = id;
+    public Product(String name, int price, String imageUrl, Category category,
+        List<Option> options) {
         this.price = price;
         this.name = name;
         this.imageUrl = imageUrl;
@@ -75,7 +77,7 @@ public class Product {
         this.category = category;
     }
 
-    public void setOption(List<Option> options){
+    public void setOption(List<Option> options) {
         this.options = options;
     }
 
@@ -85,7 +87,7 @@ public class Product {
     }
 
     public void addOptions(List<Option> options) {
-        for(Option option : options){
+        for (Option option : options) {
             addOption(option);
         }
     }
@@ -96,12 +98,12 @@ public class Product {
     }
 
     public void removeOptions(List<Option> options) {
-        for(Option option : options){
+        for (Option option : options) {
             removeOption(option);
         }
     }
 
-    public List<Option> getOptions(){
+    public List<Option> getOptions() {
         return options;
     }
 }

--- a/src/main/java/gift/administrator/product/ProductApiController.java
+++ b/src/main/java/gift/administrator/product/ProductApiController.java
@@ -57,10 +57,9 @@ public class ProductApiController {
     @PutMapping("/{id}")
     public ResponseEntity<ProductDTO> updateProduct(@PathVariable("id") Long id,
         @Valid @RequestBody ProductDTO productDTO) {
-        productDTO.setId(id);
-        productService.existsByNameAndId(productDTO.getName(), productDTO.getId());
+        productService.existsByNameAndId(productDTO.getName(), id);
 
-        ProductDTO result = productService.updateProduct(productDTO);
+        ProductDTO result = productService.updateProduct(productDTO, id);
         return ResponseEntity.ok().body(result);
     }
 

--- a/src/main/java/gift/administrator/product/ProductController.java
+++ b/src/main/java/gift/administrator/product/ProductController.java
@@ -86,16 +86,15 @@ public class ProductController {
     @PostMapping("/update/{id}")
     public String putProduct(@PathVariable("id") Long id,
         @Valid @ModelAttribute("productDTO") ProductDTO product, BindingResult result,
-        Model model)
-        throws NotFoundException {
+        Model model) {
         ProductDTO product1 = new ProductDTO(id, product.getName(), product.getPrice(),
             product.getImageUrl(), product.getCategoryId(), product.getOptions());
-        productService.existsByNameAndIdPutResult(product1.getName(), product1.getId(), result);
+        productService.existsByNameAndIdPutResult(product1.getName(), id, result);
         if (result.hasErrors()) {
             model.addAttribute("categories", categoryService.getAllCategories());
             return "update";
         }
-        productService.updateProduct(product1);
+        productService.updateProduct(product1, id);
         return "redirect:/products";
     }
 }

--- a/src/main/java/gift/administrator/product/ProductDTO.java
+++ b/src/main/java/gift/administrator/product/ProductDTO.java
@@ -45,10 +45,6 @@ public class ProductDTO {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public int getPrice() {
         return price;
     }

--- a/src/main/java/gift/administrator/product/ProductRepository.java
+++ b/src/main/java/gift/administrator/product/ProductRepository.java
@@ -6,9 +6,9 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    Boolean existsByName(String name);
+    boolean existsByName(String name);
 
-    Boolean existsByNameAndIdNot(String name, long id);
+    boolean existsByNameAndIdNot(String name, long id);
 
     @Query("SELECT DISTINCT p.category.name FROM Product p WHERE p.category IS NOT NULL")
     List<String> findDistinctCategoryNamesWithProducts();

--- a/src/main/java/gift/administrator/product/ProductService.java
+++ b/src/main/java/gift/administrator/product/ProductService.java
@@ -77,10 +77,10 @@ public class ProductService {
         return ProductDTO.fromProduct(savedProduct);
     }
 
-    public ProductDTO updateProduct(ProductDTO productDTO) {
+    public ProductDTO updateProduct(ProductDTO productDTO, Long productId) {
 
-        Product existingProduct = findByProductId(productDTO.getId());
-        existsByNameAndIdNotThrowException(productDTO.getName(), productDTO.getId());
+        Product existingProduct = findByProductId(productId);
+        existsByNameAndIdNotThrowException(productDTO.getName(), productId);
         Category newCategory = updateCategory(productDTO.getCategoryId(), existingProduct);
 
         existingProduct.update(productDTO.getName(), productDTO.getPrice(),

--- a/src/main/java/gift/administrator/product/ProductService.java
+++ b/src/main/java/gift/administrator/product/ProductService.java
@@ -4,7 +4,6 @@ import gift.administrator.category.Category;
 import gift.administrator.category.CategoryService;
 import gift.administrator.option.Option;
 import gift.administrator.option.OptionDTO;
-import gift.administrator.option.OptionService;
 import gift.error.NotFoundIdException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -95,6 +94,10 @@ public class ProductService {
 
         Product savedProduct = productRepository.save(existingProduct);
         return ProductDTO.fromProduct(savedProduct);
+    }
+
+    public boolean existsByProductId(long productId){
+        return !productRepository.existsById(productId);
     }
 
     private void existsByNameAndIdNotThrowException(String name, long productId) {

--- a/src/main/java/gift/config/FilterConfig.java
+++ b/src/main/java/gift/config/FilterConfig.java
@@ -1,0 +1,24 @@
+package gift.config;
+
+import gift.filter.JwtAuthenticationFilter;
+import gift.util.JwtUtil;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    private final JwtUtil jwtUtil;
+
+    public FilterConfig(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Bean
+    public FilterRegistrationBean<JwtAuthenticationFilter> filterBean(){
+        FilterRegistrationBean<JwtAuthenticationFilter> registrationBean = new FilterRegistrationBean<>(new JwtAuthenticationFilter(jwtUtil));
+        registrationBean.addUrlPatterns("/api/wishlist/*");
+        return registrationBean;
+    }
+}

--- a/src/main/java/gift/config/FilterConfig.java
+++ b/src/main/java/gift/config/FilterConfig.java
@@ -19,6 +19,7 @@ public class FilterConfig {
     public FilterRegistrationBean<JwtAuthenticationFilter> filterBean(){
         FilterRegistrationBean<JwtAuthenticationFilter> registrationBean = new FilterRegistrationBean<>(new JwtAuthenticationFilter(jwtUtil));
         registrationBean.addUrlPatterns("/api/wishlist/*");
+        registrationBean.addUrlPatterns("/api/orders/*");
         return registrationBean;
     }
 }

--- a/src/main/java/gift/error/GlobalExceptionRestController.java
+++ b/src/main/java/gift/error/GlobalExceptionRestController.java
@@ -25,4 +25,9 @@ public class GlobalExceptionRestController{
     public ResponseEntity<String> handleNotFoundIdException(Exception ex){
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
+
+    @ExceptionHandler(KakaoOrderException.class)
+    public ResponseEntity<String> handleKakaoOrderException(Exception ex){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
 }

--- a/src/main/java/gift/error/KakaoOrderException.java
+++ b/src/main/java/gift/error/KakaoOrderException.java
@@ -1,0 +1,7 @@
+package gift.error;
+
+public class KakaoOrderException extends RuntimeException {
+    public KakaoOrderException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gift/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/gift/filter/JwtAuthenticationFilter.java
@@ -43,9 +43,8 @@ public class JwtAuthenticationFilter implements Filter {
         String token = authHeader.substring(7);
         String tokenUserId = jwtUtil.extractUserId(token);
         String place = "";
-        if(request.getRequestURI().contains("wishlist")){
-            place = "wishlist";
-        }
+        place = containgTextReplace(request, "wishlist", place);
+        place = containgTextReplace(request, "orders", place);
 
         String path = request.getRequestURI().split(request.getContextPath() + "/api/" + place + "/")[1];
         String[] pathParts = path.split("/");
@@ -62,5 +61,12 @@ public class JwtAuthenticationFilter implements Filter {
     @Override
     public void destroy() {
         Filter.super.destroy();
+    }
+
+    private String containgTextReplace(HttpServletRequest request, String text, String place){
+        if(request.getRequestURI().contains(text)){
+            return text;
+        }
+        else return place;
     }
 }

--- a/src/main/java/gift/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/gift/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package gift.filter;
+
+import gift.util.JwtUtil;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+
+public class JwtAuthenticationFilter implements Filter {
+
+    private final JwtUtil jwtUtil;
+
+    private static final String HEADER_NAME = "Authorization";
+    private static final String HEADER_VALUE = "Bearer ";
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        Filter.super.init(filterConfig);
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+        FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        String authHeader = request.getHeader(HEADER_NAME);
+        if (authHeader == null || !authHeader.startsWith(HEADER_VALUE)) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "Unauthorized");
+            return;
+        }
+
+        String token = authHeader.substring(7);
+        String tokenUserId = jwtUtil.extractUserId(token);
+        String place = "";
+        if(request.getRequestURI().contains("wishlist")){
+            place = "wishlist";
+        }
+
+        String path = request.getRequestURI().split(request.getContextPath() + "/api/" + place + "/")[1];
+        String[] pathParts = path.split("/");
+        String userId = pathParts[0];
+
+        if (!userId.equals(tokenUserId)) {
+            response.sendError(HttpStatus.FORBIDDEN.value(), "유저 아이디가 토큰과 일치하지 않습니다.");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        Filter.super.destroy();
+    }
+}

--- a/src/main/java/gift/token/Token.java
+++ b/src/main/java/gift/token/Token.java
@@ -1,4 +1,4 @@
-package gift.users.kakao;
+package gift.token;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/gift/token/TokenRepository.java
+++ b/src/main/java/gift/token/TokenRepository.java
@@ -1,4 +1,4 @@
-package gift.users.kakao;
+package gift.token;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/gift/token/TokenRepository.java
+++ b/src/main/java/gift/token/TokenRepository.java
@@ -6,5 +6,5 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
 
     Token findByUserIdAndSns(long userId, String sns);
 
-    boolean existsByUserId(long userId);
+    boolean existsByUserIdAndSns(long userId, String sns);
 }

--- a/src/main/java/gift/token/TokenService.java
+++ b/src/main/java/gift/token/TokenService.java
@@ -12,11 +12,11 @@ public class TokenService {
         this.tokenRepository = tokenRepository;
     }
 
-    public void saveToken(Long userId, KakaoTokenDTO kakaoTokenDTO){
-        if(tokenRepository.existsByUserId(userId)){
+    public void saveToken(Long userId, KakaoTokenDTO kakaoTokenDTO, String sns){
+        if(tokenRepository.existsByUserIdAndSns(userId, sns)){
             return;
         }
-        Token token = new Token(userId, "kakao", kakaoTokenDTO.accessToken(),
+        Token token = new Token(userId, sns, kakaoTokenDTO.accessToken(),
             kakaoTokenDTO.expiresIn(), kakaoTokenDTO.refreshToken(), kakaoTokenDTO.refreshTokenExpiresIn());
         tokenRepository.save(token);
     }

--- a/src/main/java/gift/token/TokenService.java
+++ b/src/main/java/gift/token/TokenService.java
@@ -1,5 +1,6 @@
-package gift.users.kakao;
+package gift.token;
 
+import gift.users.kakao.KakaoTokenDTO;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/src/main/java/gift/users/kakao/KakaoApiResponse.java
+++ b/src/main/java/gift/users/kakao/KakaoApiResponse.java
@@ -1,0 +1,9 @@
+package gift.users.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoApiResponse(int resultCode) {
+
+}

--- a/src/main/java/gift/users/kakao/KakaoAuthApiController.java
+++ b/src/main/java/gift/users/kakao/KakaoAuthApiController.java
@@ -31,7 +31,7 @@ public class KakaoAuthApiController {
 
     @GetMapping("/token")
     public ResponseEntity<String> kakaoCallBack(@RequestParam("code") String code) {
-        String accessToken = kakaoAuthService.kakaoCallBack(code);
-        return ResponseEntity.ok(accessToken);
+        String jwtToken = kakaoAuthService.kakaoCallBack(code);
+        return ResponseEntity.ok(jwtToken);
     }
 }

--- a/src/main/java/gift/users/kakao/KakaoAuthService.java
+++ b/src/main/java/gift/users/kakao/KakaoAuthService.java
@@ -48,7 +48,7 @@ public class KakaoAuthService {
         String token = getKakaoToken(kakaoTokenDTO);
         Long userId = getKakaoUser(token);
 
-        tokenService.saveToken(userId, kakaoTokenDTO);
+        tokenService.saveToken(userId, kakaoTokenDTO, "kakao");
         return userService.loginGiveJwt(userId.toString());
     }
 
@@ -76,7 +76,7 @@ public class KakaoAuthService {
             throw new KakaoAuthenticationException("카카오 사용자 정보 값이 비어있습니다.");
         }
 
-        return userService.findByKakaoIdAndRegisterIfNotExists(kakaoUserDTO.id().toString());
+        return userService.findBySnsIdAndSnsAndRegisterIfNotExists(kakaoUserDTO.id().toString(), "kakao");
     }
 
     private KakaoTokenDTO getKakaoTokenDTO(String code){

--- a/src/main/java/gift/users/kakao/KakaoAuthService.java
+++ b/src/main/java/gift/users/kakao/KakaoAuthService.java
@@ -1,6 +1,7 @@
 package gift.users.kakao;
 
 import gift.error.KakaoAuthenticationException;
+import gift.token.TokenService;
 import gift.users.user.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/gift/users/kakao/KakaoAuthService.java
+++ b/src/main/java/gift/users/kakao/KakaoAuthService.java
@@ -42,7 +42,7 @@ public class KakaoAuthService {
     public String kakaoCallBack(String code) {
         String token = getKakaoToken(code);
         Long userId = getKakaoUser(token);
-        return userService.loginGiveToken(userId.toString());
+        return userService.loginGiveJwt(userId.toString());
     }
 
     private Long getKakaoUser(String token) {
@@ -56,7 +56,7 @@ public class KakaoAuthService {
                 .retrieve()
                 .toEntity(KakaoUserDTO.class);
         } catch(RestClientException e){
-            logger.info("Failed to receive kakao userInfo: {}", e.getMessage());
+            logger.error("Failed to receive kakao userInfo.");
             throw new KakaoAuthenticationException("카카오 사용자 값을 서버에서 가져오는 데에 실패했습니다.");
         }
 
@@ -89,7 +89,7 @@ public class KakaoAuthService {
                 .retrieve()
                 .toEntity(KakaoTokenDTO.class);
         } catch(RestClientException e){
-            logger.info("Failed to recieve kakao token: {}", e.getMessage());
+            logger.error("Failed to recieve kakao token");
             throw new KakaoAuthenticationException("카카오 토큰 값을 서버에서 가져오는 데에 실패했습니다.");
         }
 

--- a/src/main/java/gift/users/kakao/KakaoOrderApiController.java
+++ b/src/main/java/gift/users/kakao/KakaoOrderApiController.java
@@ -1,0 +1,41 @@
+package gift.users.kakao;
+
+import gift.error.KakaoOrderException;
+import gift.users.user.UserService;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+public class KakaoOrderApiController {
+
+    private final KakaoOrderService kakaoOrderService;
+    private final UserService userService;
+
+    public KakaoOrderApiController(KakaoOrderService kakaoOrderService, UserService userService) {
+        this.kakaoOrderService = kakaoOrderService;
+        this.userService = userService;
+    }
+
+    @PostMapping("/{userId}")
+    public ResponseEntity<KakaoOrderDTO> kakaoOrder(@PathVariable("userId") long userId,
+        @Valid @RequestBody KakaoOrderDTO kakaoOrderDTO){
+
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        String orderDateTime = currentDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+
+        if(!userService.findSns(userId).equals("kakao")){
+            throw new KakaoOrderException("카카오 유저만 이용할 수 있는 서비스입니다.");
+        }
+
+        KakaoOrderDTO kakaoOrderResponse = kakaoOrderService.kakaoOrder(userId, kakaoOrderDTO, orderDateTime);
+        return ResponseEntity.ok(kakaoOrderResponse);
+    }
+}

--- a/src/main/java/gift/users/kakao/KakaoOrderDTO.java
+++ b/src/main/java/gift/users/kakao/KakaoOrderDTO.java
@@ -1,0 +1,16 @@
+package gift.users.kakao;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record KakaoOrderDTO(@NotNull(message = "상품 아이디를 입력하지 않았습니다.")
+                            long productId,
+                            @NotNull(message = "옵션 아이디를 입력하지 않았습니다.")
+                            long optionId,
+                            @NotNull(message = "상품 수량을 입력하지 않았습니다.")
+                            @Min(value = 1, message = "상품은 한 개부터 구매 가능합니다.")
+                            int quantity,
+                            String orderDateTime,
+                            String message) {
+
+}

--- a/src/main/java/gift/users/kakao/KakaoOrderService.java
+++ b/src/main/java/gift/users/kakao/KakaoOrderService.java
@@ -1,0 +1,104 @@
+package gift.users.kakao;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import gift.administrator.option.OptionDTO;
+import gift.administrator.option.OptionService;
+import gift.administrator.product.ProductService;
+import gift.error.KakaoOrderException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Service
+public class KakaoOrderService {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private final TokenService tokenService;
+    private final ProductService productService;
+    private final OptionService optionService;
+    private final RestClient.Builder restClientBuilder;
+    private final KakaoProperties kakaoProperties;
+
+    private static final String HEADER_NAME = "Authorization";
+
+    public KakaoOrderService(TokenService tokenService, ProductService productService,
+        OptionService optionService, RestClient.Builder restClientBuilder,
+        KakaoProperties kakaoProperties) {
+        this.tokenService = tokenService;
+        this.productService = productService;
+        this.optionService = optionService;
+        this.restClientBuilder = restClientBuilder;
+        this.kakaoProperties = kakaoProperties;
+    }
+
+    public KakaoOrderDTO kakaoOrder(long userId, KakaoOrderDTO kakaoOrderDTO,
+        String orderDateTime) {
+
+        if(productService.existsByProductId(kakaoOrderDTO.productId())){
+            throw new KakaoOrderException("없는 상품입니다.");
+        }
+
+        OptionDTO optionDTO = optionService.findOptionById(kakaoOrderDTO.optionId());
+        if (optionDTO.getProductId() != kakaoOrderDTO.productId()) {
+            throw new KakaoOrderException(
+                kakaoOrderDTO.productId() + " 상품에 " + kakaoOrderDTO.optionId() + " 옵션이 존재하지 않습니다.");
+        }
+
+        String accessToken = tokenService.findToken(userId, "kakao");
+        String messageObject = makeKakaoMessage(kakaoOrderDTO);
+
+        sendKakaoMessage(accessToken, messageObject);
+
+        return new KakaoOrderDTO(kakaoOrderDTO.productId(), kakaoOrderDTO.optionId(),
+            kakaoOrderDTO.quantity(), orderDateTime, kakaoOrderDTO.message());
+    }
+
+    private String makeKakaoMessage(KakaoOrderDTO kakaoOrderDTO) {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ObjectNode templateObject = objectMapper.createObjectNode();
+        templateObject.put("object_type", "text");
+        templateObject.put("text",
+            "주문내역\n상품: " + productService.getProductById(kakaoOrderDTO.productId()).getName()
+                + "\n옵션: " + optionService.findOptionById(kakaoOrderDTO.optionId()).getName()
+                + "\n수량: " + kakaoOrderDTO.quantity() + "\n메시지: " + kakaoOrderDTO.message());
+
+        ObjectNode linkObject = objectMapper.createObjectNode();
+        linkObject.put("web_url", "");
+        linkObject.put("mobile_web_url", "");
+        templateObject.set("link", linkObject);
+
+        String messageObject;
+        try {
+            messageObject = objectMapper.writeValueAsString(templateObject);
+            logger.info("json: {}", messageObject);
+        } catch (JsonProcessingException e) {
+            throw new KakaoOrderException("잘못된 json 형식입니다.");
+        }
+        return URLEncoder.encode(messageObject, StandardCharsets.UTF_8);
+    }
+
+    private void sendKakaoMessage(String accessToken, String messageObject) {
+        ResponseEntity<String> response;
+        try {
+            response = restClientBuilder.build().post().uri(kakaoProperties.sendToMeUrl())
+                .header(HEADER_NAME, kakaoProperties.userHeaderValue() + " " + accessToken)
+                .body("template_object=" + messageObject).retrieve().toEntity(String.class);
+
+        } catch (RestClientException e) {
+            throw new KakaoOrderException("카카오 메시지를 보내는 데에 실패했습니다." + e);
+        }
+
+        if (response.getBody() == null || !response.getBody().contains("0")) {
+            throw new KakaoOrderException("카카오 메시지를 보내는 데에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/gift/users/kakao/KakaoOrderService.java
+++ b/src/main/java/gift/users/kakao/KakaoOrderService.java
@@ -7,6 +7,7 @@ import gift.administrator.option.OptionDTO;
 import gift.administrator.option.OptionService;
 import gift.administrator.product.ProductService;
 import gift.error.KakaoOrderException;
+import gift.token.TokenService;
 import gift.users.wishlist.WishListService;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/gift/users/kakao/KakaoOrderService.java
+++ b/src/main/java/gift/users/kakao/KakaoOrderService.java
@@ -52,10 +52,15 @@ public class KakaoOrderService {
                 kakaoOrderDTO.productId() + " 상품에 " + kakaoOrderDTO.optionId() + " 옵션이 존재하지 않습니다.");
         }
 
+        optionService.subtractOptionQuantityErrorIfNotPossible(kakaoOrderDTO.optionId(),
+            kakaoOrderDTO.quantity());
+
         String accessToken = tokenService.findToken(userId, "kakao");
         String messageObject = makeKakaoMessage(kakaoOrderDTO);
 
         sendKakaoMessage(accessToken, messageObject);
+
+        optionService.subtractOptionQuantity(kakaoOrderDTO.optionId(), kakaoOrderDTO.quantity());
 
         return new KakaoOrderDTO(kakaoOrderDTO.productId(), kakaoOrderDTO.optionId(),
             kakaoOrderDTO.quantity(), orderDateTime, kakaoOrderDTO.message());

--- a/src/main/java/gift/users/kakao/KakaoOrderService.java
+++ b/src/main/java/gift/users/kakao/KakaoOrderService.java
@@ -7,6 +7,7 @@ import gift.administrator.option.OptionDTO;
 import gift.administrator.option.OptionService;
 import gift.administrator.product.ProductService;
 import gift.error.KakaoOrderException;
+import gift.users.wishlist.WishListService;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
@@ -26,17 +27,19 @@ public class KakaoOrderService {
     private final OptionService optionService;
     private final RestClient.Builder restClientBuilder;
     private final KakaoProperties kakaoProperties;
+    private final WishListService wishListService;
 
     private static final String HEADER_NAME = "Authorization";
 
     public KakaoOrderService(TokenService tokenService, ProductService productService,
         OptionService optionService, RestClient.Builder restClientBuilder,
-        KakaoProperties kakaoProperties) {
+        KakaoProperties kakaoProperties, WishListService wishListService) {
         this.tokenService = tokenService;
         this.productService = productService;
         this.optionService = optionService;
         this.restClientBuilder = restClientBuilder;
         this.kakaoProperties = kakaoProperties;
+        this.wishListService = wishListService;
     }
 
     public KakaoOrderDTO kakaoOrder(long userId, KakaoOrderDTO kakaoOrderDTO,
@@ -62,6 +65,8 @@ public class KakaoOrderService {
 
         optionService.subtractOptionQuantity(kakaoOrderDTO.optionId(), kakaoOrderDTO.quantity());
 
+        wishListService.findOrderAndDeleteIfExists(userId, kakaoOrderDTO.productId(),
+            kakaoOrderDTO.optionId());
         return new KakaoOrderDTO(kakaoOrderDTO.productId(), kakaoOrderDTO.optionId(),
             kakaoOrderDTO.quantity(), orderDateTime, kakaoOrderDTO.message());
     }

--- a/src/main/java/gift/users/kakao/KakaoProperties.java
+++ b/src/main/java/gift/users/kakao/KakaoProperties.java
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "kakao")
 public record KakaoProperties(String clientId, String redirectUri, String authUrl,
-                              String tokenUrl, String userUrl, String loginResponseType, String userHeaderValue, String tokenGrantType) {
+                              String tokenUrl, String userUrl, String loginResponseType,
+                              String userHeaderValue, String tokenGrantType, String sendToMeUrl) {
 
 }

--- a/src/main/java/gift/users/kakao/Token.java
+++ b/src/main/java/gift/users/kakao/Token.java
@@ -1,0 +1,41 @@
+package gift.users.kakao;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Token {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+    @Column(nullable = false)
+    private Long userId;
+    @Column(nullable = false)
+    private String sns;
+    @Column(nullable = false)
+    private String accessToken;
+    private int expiresIn;
+    private String refreshToken;
+    private int refreshTokenExpiresIn;
+
+    public Token() {
+    }
+
+    public Token(Long userId, String sns, String accessToken, int expiresIn, String refreshToken,
+        int refreshTokenExpiresIn) {
+        this.userId = userId;
+        this.sns = sns;
+        this.accessToken = accessToken;
+        this.expiresIn = expiresIn;
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
+    }
+
+    public String getAccessToken(){
+        return accessToken;
+    }
+}

--- a/src/main/java/gift/users/kakao/TokenRepository.java
+++ b/src/main/java/gift/users/kakao/TokenRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TokenRepository extends JpaRepository<Token, Long> {
 
     Token findByUserIdAndSns(long userId, String sns);
+
+    boolean existsByUserId(long userId);
 }

--- a/src/main/java/gift/users/kakao/TokenRepository.java
+++ b/src/main/java/gift/users/kakao/TokenRepository.java
@@ -1,0 +1,8 @@
+package gift.users.kakao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+
+    Token findByUserIdAndSns(long userId, String sns);
+}

--- a/src/main/java/gift/users/kakao/TokenService.java
+++ b/src/main/java/gift/users/kakao/TokenService.java
@@ -12,6 +12,9 @@ public class TokenService {
     }
 
     public void saveToken(Long userId, KakaoTokenDTO kakaoTokenDTO){
+        if(tokenRepository.existsByUserId(userId)){
+            return;
+        }
         Token token = new Token(userId, "kakao", kakaoTokenDTO.accessToken(),
             kakaoTokenDTO.expiresIn(), kakaoTokenDTO.refreshToken(), kakaoTokenDTO.refreshTokenExpiresIn());
         tokenRepository.save(token);

--- a/src/main/java/gift/users/kakao/TokenService.java
+++ b/src/main/java/gift/users/kakao/TokenService.java
@@ -1,0 +1,23 @@
+package gift.users.kakao;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TokenService {
+
+    private final TokenRepository tokenRepository;
+
+    public TokenService(TokenRepository tokenRepository) {
+        this.tokenRepository = tokenRepository;
+    }
+
+    public void saveToken(Long userId, KakaoTokenDTO kakaoTokenDTO){
+        Token token = new Token(userId, "kakao", kakaoTokenDTO.accessToken(),
+            kakaoTokenDTO.expiresIn(), kakaoTokenDTO.refreshToken(), kakaoTokenDTO.refreshTokenExpiresIn());
+        tokenRepository.save(token);
+    }
+
+    public String findToken(long userId, String sns){
+        return tokenRepository.findByUserIdAndSns(userId, sns).getAccessToken();
+    }
+}

--- a/src/main/java/gift/users/kakao/kakaoMessage/Button.java
+++ b/src/main/java/gift/users/kakao/kakaoMessage/Button.java
@@ -1,0 +1,5 @@
+package gift.users.kakao.kakaoMessage;
+
+public record Button(String title, Link link) {
+
+}

--- a/src/main/java/gift/users/kakao/kakaoMessage/Commerce.java
+++ b/src/main/java/gift/users/kakao/kakaoMessage/Commerce.java
@@ -1,0 +1,9 @@
+package gift.users.kakao.kakaoMessage;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record Commerce(String productName, int regularPrice) {
+
+}

--- a/src/main/java/gift/users/kakao/kakaoMessage/Content.java
+++ b/src/main/java/gift/users/kakao/kakaoMessage/Content.java
@@ -1,0 +1,10 @@
+package gift.users.kakao.kakaoMessage;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record Content(String title, String imageUrl, int imageWidth, int imageHeight,
+                      String description, Link link) {
+
+}

--- a/src/main/java/gift/users/kakao/kakaoMessage/KakaoMessageTemplate.java
+++ b/src/main/java/gift/users/kakao/kakaoMessage/KakaoMessageTemplate.java
@@ -1,0 +1,10 @@
+package gift.users.kakao.kakaoMessage;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoMessageTemplate(String objectType, Content content, Commerce commerce, List<Button> buttons) {
+
+}

--- a/src/main/java/gift/users/kakao/kakaoMessage/Link.java
+++ b/src/main/java/gift/users/kakao/kakaoMessage/Link.java
@@ -1,0 +1,9 @@
+package gift.users.kakao.kakaoMessage;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record Link(String webUrl, String mobileWebUrl) {
+
+}

--- a/src/main/java/gift/users/user/User.java
+++ b/src/main/java/gift/users/user/User.java
@@ -18,28 +18,28 @@ public class User {
     private String email;
     private String password;
     @Column(unique = true)
-    private String kakaoId;
+    private String snsId;
     private String sns;
 
     public User() {
     }
 
-    public User(String kakaoId) {
-        this.kakaoId = kakaoId;
-        this.sns = "kakao";
+    public User(String snsId, String sns) {
+        this.snsId = snsId;
+        this.sns = sns;
     }
 
-    public User(String email, String password) {
-        this.email = email;
-        this.password = password;
-        this.sns = "local";
-    }
-
-    public User(Long id, String email, String password) {
+    public User(Long id, String email, String password, String sns) {
         this.id = id;
         this.email = email;
         this.password = password;
-        this.sns = "local";
+        this.sns = sns;
+    }
+
+    public User(String email, String password, String sns) {
+        this.email = email;
+        this.password = password;
+        this.sns = sns;
     }
 
     public Long getId() {
@@ -55,4 +55,6 @@ public class User {
     }
 
     public String getSns(){return sns;}
+
+    public String getSnsId(){return snsId;}
 }

--- a/src/main/java/gift/users/user/User.java
+++ b/src/main/java/gift/users/user/User.java
@@ -19,23 +19,27 @@ public class User {
     private String password;
     @Column(unique = true)
     private String kakaoId;
+    private String sns;
 
     public User() {
     }
 
     public User(String kakaoId) {
         this.kakaoId = kakaoId;
+        this.sns = "kakao";
     }
 
     public User(String email, String password) {
         this.email = email;
         this.password = password;
+        this.sns = "local";
     }
 
     public User(Long id, String email, String password) {
         this.id = id;
         this.email = email;
         this.password = password;
+        this.sns = "local";
     }
 
     public Long getId() {
@@ -49,4 +53,6 @@ public class User {
     public String getPassword() {
         return password;
     }
+
+    public String getSns(){return sns;}
 }

--- a/src/main/java/gift/users/user/User.java
+++ b/src/main/java/gift/users/user/User.java
@@ -1,9 +1,11 @@
 package gift.users.user;
 
-import gift.users.wishlist.WishList;
-import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Table(name = "users")
 @Entity
@@ -17,8 +19,6 @@ public class User {
     private String password;
     @Column(unique = true)
     private String kakaoId;
-    @OneToMany(mappedBy = "user", orphanRemoval = true, cascade = CascadeType.ALL)
-    private List<WishList> wishes = new ArrayList<>();
 
     public User() {
     }
@@ -48,23 +48,5 @@ public class User {
 
     public String getPassword() {
         return password;
-    }
-
-    public String getKakaoId() {
-        return kakaoId;
-    }
-
-    public List<WishList> getWishes() {
-        return wishes;
-    }
-
-    public void addWishList(WishList wishList) {
-        this.wishes.add(wishList);
-        wishList.setUser(this);
-    }
-
-    public void removeWishList(WishList wishList) {
-        wishes.remove(wishList);
-        wishList.setUser(null);
     }
 }

--- a/src/main/java/gift/users/user/UserDTO.java
+++ b/src/main/java/gift/users/user/UserDTO.java
@@ -1,12 +1,13 @@
 package gift.users.user;
 
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 public record UserDTO(Long id,
                       @Email
-                      @NotNull(message = "이메일을 입력하지 않았습니다.")
+                      @NotBlank(message = "이메일을 입력하지 않았습니다.")
                       String email,
-                      @NotNull(message = "비밀번호를 입력하지 않았습니다.")
+                      @NotBlank(message = "비밀번호를 입력하지 않았습니다.")
                       String password) {
 
     public User toUser() {

--- a/src/main/java/gift/users/user/UserDTO.java
+++ b/src/main/java/gift/users/user/UserDTO.java
@@ -8,13 +8,14 @@ public record UserDTO(Long id,
                       @NotBlank(message = "이메일을 입력하지 않았습니다.")
                       String email,
                       @NotBlank(message = "비밀번호를 입력하지 않았습니다.")
-                      String password) {
+                      String password,
+                      String sns) {
 
     public User toUser() {
-        return new User(id, email, password);
+        return new User(id, email, password, "local");
     }
 
     public static UserDTO fromUser(User user) {
-        return new UserDTO(user.getId(), user.getEmail(), user.getPassword());
+        return new UserDTO(user.getId(), user.getEmail(), user.getPassword(), "local");
     }
 }

--- a/src/main/java/gift/users/user/UserRepository.java
+++ b/src/main/java/gift/users/user/UserRepository.java
@@ -10,7 +10,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmailAndPassword(String email, String password);
 
-    boolean existsByKakaoId(String kakaoId);
+    boolean existsBySnsIdAndSns(String snsId, String sns);
 
-    User findByKakaoId(String kakaoId);
+    User findBySnsIdAndSns(String snsId, String sns);
 }

--- a/src/main/java/gift/users/user/UserService.java
+++ b/src/main/java/gift/users/user/UserService.java
@@ -25,10 +25,10 @@ public class UserService {
         return user.getId();
     }
 
-    public String loginGiveToken(String userId) {
-        String token = jwtUtil.generateToken(userId);
-        if (token != null) {
-            return "access-token: " + token;
+    public String loginGiveJwt(String userId) {
+        String jwtToken = jwtUtil.generateToken(userId);
+        if (jwtToken != null) {
+            return "access-token: " + jwtToken;
         }
         throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "토큰 생성 실패");
     }
@@ -54,7 +54,7 @@ public class UserService {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User Not Found");
         }
         UserDTO userDTO = findUserByEmail(email);
-        return loginGiveToken(userDTO.id().toString());
+        return loginGiveJwt(userDTO.id().toString());
     }
 
     public boolean registerUser(UserDTO userDTO) {

--- a/src/main/java/gift/users/user/UserService.java
+++ b/src/main/java/gift/users/user/UserService.java
@@ -25,6 +25,11 @@ public class UserService {
         return user.getId();
     }
 
+    public String findSns(long userId){
+        User user = findUserById(userId);
+        return user.getSns();
+    }
+
     public String loginGiveJwt(String userId) {
         String jwtToken = jwtUtil.generateToken(userId);
         if (jwtToken != null) {
@@ -66,9 +71,13 @@ public class UserService {
         return true;
     }
 
+    private User findUserById(long id){
+        return userRepository.findById(id)
+            .orElseThrow(() -> new NotFoundIdException("없는 회원 아이디입니다."));
+    }
+
     public UserDTO findById(long id) {
-        return UserDTO.fromUser(userRepository.findById(id)
-            .orElseThrow(() -> new NotFoundIdException("없는 회원 아이디입니다.")));
+        return UserDTO.fromUser(findUserById(id));
     }
 
     public UserDTO findUserByEmail(String email) {

--- a/src/main/java/gift/users/user/UserService.java
+++ b/src/main/java/gift/users/user/UserService.java
@@ -17,11 +17,11 @@ public class UserService {
         this.jwtUtil = jwtUtil;
     }
 
-    public Long findByKakaoIdAndRegisterIfNotExists(String kakaoId) {
-        if (!userRepository.existsByKakaoId(kakaoId)) {
-            userRepository.save(new User(kakaoId));
+    public Long findBySnsIdAndSnsAndRegisterIfNotExists(String snsId, String sns) {
+        if (!userRepository.existsBySnsIdAndSns(snsId, sns)) {
+            userRepository.save(new User(snsId, sns));
         }
-        User user = userRepository.findByKakaoId(kakaoId);
+        User user = userRepository.findBySnsIdAndSns(snsId, sns);
         return user.getId();
     }
 

--- a/src/main/java/gift/users/wishlist/WishList.java
+++ b/src/main/java/gift/users/wishlist/WishList.java
@@ -3,7 +3,15 @@ package gift.users.wishlist;
 import gift.administrator.option.Option;
 import gift.administrator.product.Product;
 import gift.users.user.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Min;
 
 @Table(name = "wishlist")
@@ -17,7 +25,7 @@ public class WishList {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id", nullable = false, unique = true)
+    @JoinColumn(name = "product_id", nullable = false)
     private Product product;
     @Column(nullable = false)
     @Min(value = 1)

--- a/src/main/java/gift/users/wishlist/WishList.java
+++ b/src/main/java/gift/users/wishlist/WishList.java
@@ -44,10 +44,6 @@ public class WishList {
         this.option = option;
     }
 
-    public void update(int num) {
-        this.num = num;
-    }
-
     public Long getId() {
         return id;
     }

--- a/src/main/java/gift/users/wishlist/WishListApiController.java
+++ b/src/main/java/gift/users/wishlist/WishListApiController.java
@@ -35,7 +35,6 @@ public class WishListApiController {
         @RequestParam(value = "sortBy", required = false, defaultValue = "id") String sortBy,
         @RequestParam(value = "sortDirection", required = false, defaultValue = "asc") String sortDirection) {
 
-        wishListService.extractUserIdFromTokenAndValidate(request, userId);
         size = PageUtil.validateSize(size);
         sortBy = PageUtil.validateSortBy(sortBy, Arrays.asList("id", "productId", "num"));
         Direction direction = PageUtil.validateDirection(sortDirection);
@@ -49,7 +48,6 @@ public class WishListApiController {
     public ResponseEntity<WishListDTO> addWishList(@PathVariable("userId") long userId,
         HttpServletRequest request, @RequestBody WishListDTO wishListDTO) {
 
-        wishListService.extractUserIdFromTokenAndValidate(request, userId);
         WishListDTO result = wishListService.addWishList(wishListDTO, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
@@ -59,7 +57,6 @@ public class WishListApiController {
         @PathVariable("productId") long productId, HttpServletRequest request,
         @RequestBody WishListDTO wishListDTO) {
 
-        wishListService.extractUserIdFromTokenAndValidate(request, userId);
         WishListDTO result = wishListService.updateWishList(userId, productId,
             wishListDTO);
         return ResponseEntity.ok().body(result);
@@ -69,7 +66,6 @@ public class WishListApiController {
     public ResponseEntity<Void> deleteWishList(@PathVariable("userId") long userId,
         @PathVariable("productId") long productId, HttpServletRequest request) {
 
-        wishListService.extractUserIdFromTokenAndValidate(request, userId);
         wishListService.deleteWishList(userId, productId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/gift/users/wishlist/WishListApiController.java
+++ b/src/main/java/gift/users/wishlist/WishListApiController.java
@@ -1,7 +1,7 @@
 package gift.users.wishlist;
 
 import gift.util.PageUtil;
-import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.Arrays;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort.Direction;
@@ -29,7 +29,6 @@ public class WishListApiController {
 
     @GetMapping("/{userId}")
     public ResponseEntity<Page<WishListDTO>> getWishList(@PathVariable("userId") long userId,
-        HttpServletRequest request,
         @RequestParam(value = "page", required = false, defaultValue = "0") int page,
         @RequestParam(value = "size", required = false, defaultValue = "10") int size,
         @RequestParam(value = "sortBy", required = false, defaultValue = "id") String sortBy,
@@ -46,27 +45,27 @@ public class WishListApiController {
 
     @PostMapping("/{userId}")
     public ResponseEntity<WishListDTO> addWishList(@PathVariable("userId") long userId,
-        HttpServletRequest request, @RequestBody WishListDTO wishListDTO) {
+        @Valid @RequestBody WishListDTO wishListDTO) {
 
         WishListDTO result = wishListService.addWishList(wishListDTO, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 
-    @PutMapping("/{userId}/{productId}")
+    @PutMapping("/{userId}/{wishListId}")
     public ResponseEntity<WishListDTO> updateWishList(@PathVariable("userId") long userId,
-        @PathVariable("productId") long productId, HttpServletRequest request,
-        @RequestBody WishListDTO wishListDTO) {
+        @PathVariable("wishListId") long wishListId,
+        @Valid @RequestBody WishListDTO wishListDTO) {
 
-        WishListDTO result = wishListService.updateWishList(userId, productId,
+        WishListDTO result = wishListService.updateWishList(userId, wishListId,
             wishListDTO);
         return ResponseEntity.ok().body(result);
     }
 
-    @DeleteMapping("/{userId}/{productId}")
-    public ResponseEntity<Void> deleteWishList(@PathVariable("userId") long userId,
-        @PathVariable("productId") long productId, HttpServletRequest request) {
+    @DeleteMapping("/{userId}/{wishListId}")
+    public ResponseEntity<Void> deleteWishListByWishListId(@PathVariable("userId") long userId,
+        @PathVariable("wishListId") long wishListId) {
 
-        wishListService.deleteWishList(userId, productId);
+        wishListService.deleteWishListByWishListId(userId, wishListId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/gift/users/wishlist/WishListDTO.java
+++ b/src/main/java/gift/users/wishlist/WishListDTO.java
@@ -1,10 +1,19 @@
 package gift.users.wishlist;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
 public class WishListDTO {
 
     private long userId;
+    @NotNull(message = "상품 아이디를 입력하지 않았습니다.")
+    @Min(value = 1, message = "상품 아이디는 1 이하일 수 없습니다.")
     private long productId;
+    @NotNull(message = "상품 수량을 입력하지 않았습니다.")
+    @Min(value = 1, message = "상품 수량은 1 이하일 수 없습니다.")
     private int num;
+    @NotNull(message = "옵션 아이디를 입력하지 않았습니다.")
+    @Min(value = 1, message = "옵션 아이디는 1 이하일 수 없습니다.")
     private long optionId;
 
     public WishListDTO() {

--- a/src/main/java/gift/users/wishlist/WishListRepository.java
+++ b/src/main/java/gift/users/wishlist/WishListRepository.java
@@ -11,9 +11,11 @@ public interface WishListRepository extends JpaRepository<WishList, Long> {
 
     List<WishList> findAllByUserId(long id);
 
-    WishList findByUserIdAndProductId(long userId, long productId);
+    void deleteByUserIdAndProductIdAndOptionId(long userId, long productId, long optionId);
 
-    Boolean existsByUserIdAndProductId(long userId, long productId);
+    boolean existsByIdAndUserId(long wishListId, long userId);
 
-    void deleteByUserIdAndProductId(long userId, long productId);
+    boolean existsByUserIdAndProductIdAndOptionId(long userId, long productId, long optionId);
+
+    boolean existsByUserIdAndProductIdAndOptionIdAndIdNot(long userId, long productId, long optionId, long wishListId);
 }

--- a/src/main/java/gift/users/wishlist/WishListRepository.java
+++ b/src/main/java/gift/users/wishlist/WishListRepository.java
@@ -1,6 +1,5 @@
 package gift.users.wishlist;
 
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,8 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface WishListRepository extends JpaRepository<WishList, Long> {
 
     Page<WishList> findAllByUserId(long id, Pageable pageable);
-
-    List<WishList> findAllByUserId(long id);
 
     void deleteByUserIdAndProductIdAndOptionId(long userId, long productId, long optionId);
 

--- a/src/main/java/gift/util/JwtUtil.java
+++ b/src/main/java/gift/util/JwtUtil.java
@@ -16,11 +16,11 @@ public class JwtUtil {
     private String secretKey;
 
     @Value("${jwt.expiration}")
-    private Long expiration;
+    private long expiration;
 
-    public String generateToken(String emailOrId){
+    public String generateToken(String userId){
         return Jwts.builder()
-            .setSubject(emailOrId)
+            .setSubject(userId)
             .setIssuedAt(new Date(System.currentTimeMillis()))
             .setExpiration(new Date(System.currentTimeMillis() + expiration))
             .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))

--- a/src/test/java/gift/controller/CategoryApiControllerTest.java
+++ b/src/test/java/gift/controller/CategoryApiControllerTest.java
@@ -89,7 +89,7 @@ public class CategoryApiControllerTest {
         //given
         CategoryDTO categoryDTO = new CategoryDTO(1L, "상품권", "#ff11ff", "image.jpg", "");
         doNothing().when(categoryService).existsByNameThrowException(any());
-        given(categoryService.addCategory(categoryDTO)).willReturn(categoryDTO);
+        given(categoryService.addCategory(any(CategoryDTO.class))).willReturn(categoryDTO);
 
         //when
         ResultActions resultActions = mvc.perform(
@@ -98,7 +98,8 @@ public class CategoryApiControllerTest {
                 .content(objectMapper.writeValueAsString(categoryDTO)));
 
         //then
-        resultActions.andExpect(status().isCreated());
+        resultActions.andExpect(status().isCreated())
+            .andExpect(content().json(objectMapper.writeValueAsString(categoryDTO)));
     }
 
     @Test
@@ -125,7 +126,7 @@ public class CategoryApiControllerTest {
         //given
         CategoryDTO categoryDTO = new CategoryDTO(1L, "상품권", "#ff11ff", "image.jpg", "");
         doNothing().when(categoryService).existsByNameAndId(anyString(), anyLong());
-        given(categoryService.updateCategory(any(CategoryDTO.class))).willReturn(categoryDTO);
+        given(categoryService.updateCategory(any(CategoryDTO.class), 1L)).willReturn(categoryDTO);
 
         //when
         ResultActions resultActions = mvc.perform(

--- a/src/test/java/gift/controller/KakaoOrderApiControllerTest.java
+++ b/src/test/java/gift/controller/KakaoOrderApiControllerTest.java
@@ -1,0 +1,87 @@
+package gift.controller;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.error.KakaoOrderException;
+import gift.users.kakao.KakaoOrderApiController;
+import gift.users.kakao.KakaoOrderDTO;
+import gift.users.kakao.KakaoOrderService;
+import gift.users.kakao.KakaoProperties;
+import gift.users.user.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class KakaoOrderApiControllerTest {
+
+    private final KakaoOrderService kakaoOrderService = mock(KakaoOrderService.class);
+    private MockMvc mvc;
+    private KakaoOrderApiController kakaoOrderApiController;
+    private UserService userService = mock(UserService.class);
+    private ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private KakaoProperties kakaoProperties;
+
+    @BeforeEach
+    void beforeEach(){
+        kakaoOrderApiController = new KakaoOrderApiController(kakaoOrderService, userService);
+        mvc = MockMvcBuilders.standaloneSetup(kakaoOrderApiController)
+            .defaultResponseCharacterEncoding(UTF_8)
+            .build();
+    }
+
+    @Test
+    @DisplayName("카카오 주문하기")
+    void kakaoOrder() throws Exception {
+        //given
+        given(userService.findSns(anyLong())).willReturn("kakao");
+        KakaoOrderDTO kakaoOrderDTO = new KakaoOrderDTO(1L,
+            1L, 2, "1", "hello");
+        KakaoOrderDTO kakaoOrderResponse = new KakaoOrderDTO(1L,
+            1L, 2, "2024-10-11", "hello");
+        given(kakaoOrderService.kakaoOrder(anyLong(), any(KakaoOrderDTO.class), anyString()))
+            .willReturn(kakaoOrderResponse);
+
+        //when
+        ResultActions resultActions = mvc.perform(
+            MockMvcRequestBuilders.post("/api/orders/1")
+                .contentType("application/json")
+                .content(objectMapper.writeValueAsString(kakaoOrderDTO)));
+
+        //then
+        resultActions.andExpect(status().isOk())
+            .andExpect(content().json(objectMapper.writeValueAsString(kakaoOrderResponse)));
+    }
+
+    @Test
+    @DisplayName("카카오 주문하기 실패 카카오 회원만 이용 가능")
+    void kakaoOrderFailedOnlyKakaoUsersAllowed() {
+        //given
+        given(userService.findSns(anyLong())).willReturn("local");
+        KakaoOrderDTO kakaoOrderDTO = new KakaoOrderDTO(1L,
+            1L, 2, "1", "hello");
+
+        //when
+
+        //then
+        assertThatThrownBy(() -> kakaoOrderApiController.kakaoOrder(1L, kakaoOrderDTO))
+            .isInstanceOf(KakaoOrderException.class)
+            .hasMessageContaining("카카오 유저만 이용할 수 있는 서비스입니다.");
+    }
+}

--- a/src/test/java/gift/controller/OptionApiControllerTest.java
+++ b/src/test/java/gift/controller/OptionApiControllerTest.java
@@ -44,10 +44,10 @@ public class OptionApiControllerTest {
             .build();
         objectMapper = new ObjectMapper();
         Category category = new Category("상품권", null, null, null);
-        Option option = new Option(1L, "L", 3, null);
+        Option option = new Option("L", 3, null);
         List<Option> options = new ArrayList<>(List.of(option));
-        Product product = new Product(1L, "라이언", 1000, "image.jpg", category, options);
-        optionDTO1 = new OptionDTO(2L, "XL", 5, 1L);
+        Product product = new Product("라이언", 1000, "image.jpg", category, options);
+        optionDTO1 = new OptionDTO("XL", 5, 1L);
         option.setProduct(product);
         optionDTO = OptionDTO.fromOption(option);
     }

--- a/src/test/java/gift/repository/CategoryRepositoryTest.java
+++ b/src/test/java/gift/repository/CategoryRepositoryTest.java
@@ -121,6 +121,32 @@ public class CategoryRepositoryTest {
     }
 
     @Test
+    @DisplayName("카테고리 아이디로 찾기")
+    void existsById() {
+        //Given
+        categoryRepository.save(category);
+
+        //When
+        boolean actual = categoryRepository.existsById(category.getId());
+
+        //Then
+        assertThat(actual).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리 아이디로 카테고리를 찾으면 false 리턴")
+    void notExistsById() {
+        //Given
+        categoryRepository.save(category);
+
+        //When
+        boolean actual = categoryRepository.existsById(category.getId() + 1);
+
+        //Then
+        assertThat(actual).isEqualTo(false);
+    }
+
+    @Test
     @DisplayName("카테고리 이름으로 찾기")
     void existsByName() {
         //Given
@@ -141,6 +167,32 @@ public class CategoryRepositoryTest {
 
         //When
         boolean actual = categoryRepository.existsByName("이춘식");
+
+        //Then
+        assertThat(actual).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("카테고리 이름은 존재하지만 카테고리 아이디는 존재하지 않음")
+    void existsByNameAndIdNot() {
+        //Given
+        categoryRepository.save(category);
+
+        //When
+        boolean actual = categoryRepository.existsByNameAndIdNot(category.getName(), category.getId() + 1);
+
+        //Then
+        assertThat(actual).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("카테고리 이름이 존재하지 않거나 카테고리 아이디가 존재함")
+    void existsByNameAndIdNotReturnsFalse() {
+        //Given
+        categoryRepository.save(category);
+
+        //When
+        boolean actual = categoryRepository.existsByNameAndIdNot(category.getName(), category.getId());
 
         //Then
         assertThat(actual).isEqualTo(false);

--- a/src/test/java/gift/repository/OptionRepositoryTest.java
+++ b/src/test/java/gift/repository/OptionRepositoryTest.java
@@ -45,7 +45,7 @@ public class OptionRepositoryTest {
 
     @Test
     @DisplayName("전부 찾기")
-    void findAll(){
+    void findAll() {
         //given
         Option expected = new Option("L", 3, product);
         Option option1 = new Option("XL", 3, null);
@@ -72,7 +72,7 @@ public class OptionRepositoryTest {
 
     @Test
     @DisplayName("옵션 아이디로 전부 찾기")
-    void findAllById(){
+    void findAllById() {
         //given
         Option expected = new Option("L", 3, product);
         Option option1 = new Option("XL", 3, null);
@@ -100,7 +100,7 @@ public class OptionRepositoryTest {
 
     @Test
     @DisplayName("상품 아이디로 전부 찾기")
-    void findAllByProductId(){
+    void findAllByProductId() {
         //given
         Option expected = new Option("L", 3, product);
         Option option1 = new Option("XL", 3, null);
@@ -127,7 +127,7 @@ public class OptionRepositoryTest {
 
     @Test
     @DisplayName("옵션 아이디로 하나 찾기")
-    void findById(){
+    void findById() {
         //given
         Option expected = new Option("L", 3, product);
 
@@ -143,11 +143,11 @@ public class OptionRepositoryTest {
 
     @Test
     @DisplayName("옵션 아이디로 하나 찾을 때 아이디 존재하지 않음")
-    void findByIdNotFound(){
+    void findByIdNotFound() {
         //given
 
         //when
-        Optional<Option> actual = optionRepository.findById(option.getId()+1);
+        Optional<Option> actual = optionRepository.findById(option.getId() + 1);
 
         //then
         assertThat(actual).isNotPresent();
@@ -155,7 +155,7 @@ public class OptionRepositoryTest {
 
     @Test
     @DisplayName("옵션 저장하기")
-    void save(){
+    void save() {
         //given
         Option expected = new Option("L", 3, product);
 
@@ -171,7 +171,7 @@ public class OptionRepositoryTest {
 
     @Test
     @DisplayName("옵션 아이디로 삭제하기")
-    void deleteById(){
+    void deleteById() {
         //given
         product = productRepository.save(product);
 
@@ -185,7 +185,7 @@ public class OptionRepositoryTest {
 
     @Test
     @DisplayName("상품 아이디와 옵션 아이디로 존재 여부 확인 시 존재할 때")
-    void existsByIdAndProductId(){
+    void existsByIdAndProductId() {
         //given
         product = productRepository.save(product);
 
@@ -198,7 +198,7 @@ public class OptionRepositoryTest {
 
     @Test
     @DisplayName("상품 아이디와 옵션 아이디로 존재 여부 확인시 존재하지 않을 때")
-    void existsByIdAndProductIdButNotExists(){
+    void existsByIdAndProductIdButNotExists() {
         //given
         product = productRepository.save(product);
         Option option1 = new Option("L", 3, null);
@@ -213,5 +213,49 @@ public class OptionRepositoryTest {
 
         //then
         assertThat(actual).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("옵션 이름과 상품 아이디로 존재하지만 옵션 아이디는 존재하지 않음")
+    void existsByNameAndProductIdAndIdNot() {
+        //given
+        product = productRepository.save(product);
+
+        //when
+        boolean actual = optionRepository.existsByNameAndProductIdAndIdNot(option.getName(),
+            product.getId(), option.getId() + 1);
+
+        //then
+        assertThat(actual).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("옵션 이름과 상품 아이디로 존재하지 않거나 옵션 아이디가 존재함")
+    void existsByNameAndProductIdAndIdNotReturnsFalse() {
+        //given
+        product = productRepository.save(product);
+
+        //when
+        boolean actual = optionRepository.existsByNameAndProductIdAndIdNot(option.getName(),
+            product.getId(), option.getId());
+
+        //then
+        assertThat(actual).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("상품 아이디로 개수 전부 세기")
+    void countAllByProductId() {
+        //given
+        product = productRepository.save(product);
+        Option option1 = new Option("XL", 3, null);
+        option1.setProduct(product);
+        optionRepository.save(option1);
+
+        //when
+        int actual = optionRepository.countAllByProductId(product.getId());
+
+        //then
+        assertThat(actual).isEqualTo(2);
     }
 }

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -15,6 +15,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @DataJpaTest
 public class ProductRepositoryTest {
@@ -85,23 +89,151 @@ public class ProductRepositoryTest {
     @DisplayName("전체 상품 찾기 테스트")
     void findAll() {
         //Given
+        int page = 0;
+        int size = 10;
+        String sortBy = "id";
+        Sort.Direction direction = Sort.Direction.ASC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
+
         productRepository.save(product);
-        Product product2 = new Product("이춘식", 3000, "example.jpg", category, options);
-        productRepository.save(product2);
+        Category category = new Category(1L, "도서", null, null, null);
+        Option option = new Option("어린왕자", 3, null);
+        category = categoryRepository.save(category);
+        Product product1 = new Product(1L, "Product1", 1000, "imageUrl1", category, List.of(option));
+        product1 = productRepository.save(product1);
+        option.setProduct(product1);
+
+        List<Product> expected = List.of(product, product1);
 
         //When
-        List<Product> actual = productRepository.findAll();
+        Page<Product> result = productRepository.findAll(pageable);
 
         //Then
-        assertThat(actual).hasSize(2);
-        assertThat(actual.getFirst().getId()).isNotNull();
-        assertThat(actual.get(1).getId()).isNotNull();
-        assertThat(actual)
-            .containsExactly(product, product2);
+        assertThat(result.getTotalElements()).isEqualTo(expected.size());
+        assertThat(result.getContent().get(0))
+            .extracting(Product::getName, Product::getPrice, Product::getImageUrl, Product::getCategory)
+            .containsExactly(expected.getFirst().getName(), expected.getFirst().getPrice(),
+                expected.getFirst().getImageUrl(), expected.getFirst().getCategory());
+        assertThat(result.getContent().get(1))
+            .extracting(Product::getName, Product::getPrice, Product::getImageUrl, Product::getCategory)
+            .containsExactly(expected.get(1).getName(), expected.get(1).getPrice(),
+                expected.get(1).getImageUrl(), expected.get(1).getCategory());
+    }
+
+    @Test
+    @DisplayName("상품 아이디로 존재 여부 확인 시 존재함")
+    void findDistinctCategoryNamesWithProducts() {
+        //Given
+        productRepository.save(product);
+        Category category = new Category(1L, "도서", null, null, null);
+        Option option = new Option("어린왕자", 3, null);
+        category = categoryRepository.save(category);
+        Product product1 = new Product(1L, "Product1", 1000, "imageUrl1", category, List.of(option));
+        product1 = productRepository.save(product1);
+        option.setProduct(product1);
+        List<String> expected = List.of(product.getCategory().getName(), category.getName());
+
+        //When
+        List<String> actual = productRepository.findDistinctCategoryNamesWithProducts();
+
+        //Then
+        assertThat(actual).containsAll(expected);
+    }
+
+    @Test
+    @DisplayName("상품 아이디로 존재 여부 확인 시 존재함")
+    void existsById() {
+        //Given
+        productRepository.save(product);
+
+        //When
+        boolean actual = productRepository.existsById(product.getId());
+
+        //Then
+        assertThat(actual).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("상품 아이디로 존재 여부 확인 시 존재하지 않음")
+    void notExistsById() {
+        //Given
+        productRepository.save(product);
+
+        //When
+        boolean actual = productRepository.existsById(product.getId() + 1);
+
+        //Then
+        assertThat(actual).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("상품 이름으로 상품 존재 여부 확인 시 존재함")
+    void existsByName() {
+        //Given
+        productRepository.save(product);
+
+        //When
+        boolean actual = productRepository.existsByName(product.getName());
+
+        //Then
+        assertThat(actual).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("상품 이름으로 상품 존재 여부 확인 시 존재하지 않음")
+    void notExistsByName() {
+        //Given
+        productRepository.save(product);
+
+        //When
+        boolean actual = productRepository.existsByName("라면");
+
+        //Then
+        assertThat(actual).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("상품 이름 존재하지만 상품 아이디로 존재하지 않음")
+    void existsByNameAndIdNot() {
+        //Given
+        productRepository.save(product);
+
+        //When
+        boolean actual = productRepository.existsByNameAndIdNot(product.getName(), product.getId() + 1);
+
+        //Then
+        assertThat(actual).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("상품 이름 존재하지 않거나 상품 아이디로 존재함")
+    void existsByNameAndIdNotReturnsFalse() {
+        //Given
+        productRepository.save(product);
+
+        //When
+        boolean actual = productRepository.existsByNameAndIdNot(product.getName(), product.getId());
+
+        //Then
+        assertThat(actual).isEqualTo(false);
     }
 
     @Test
     @DisplayName("상품 삭제 테스트")
+    void delete() {
+        //Given
+        productRepository.save(product);
+
+        //When
+        productRepository.delete(product);
+        Optional<Product> actual = productRepository.findById(product.getId());
+
+        //Then
+        assertThat(actual).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("상품아이디로 상품 삭제 테스트")
     void deleteById() {
         //Given
         productRepository.save(product);

--- a/src/test/java/gift/repository/TokenRepositoryTest.java
+++ b/src/test/java/gift/repository/TokenRepositoryTest.java
@@ -1,0 +1,84 @@
+package gift.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gift.token.Token;
+import gift.token.TokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class TokenRepositoryTest {
+
+    @Autowired
+    private TokenRepository tokenRepository;
+    private Token token;
+
+    @BeforeEach
+    void beforeEach(){
+        token = new Token(1L, "kakao", "1234", 360000, "5678",
+        360000);
+    }
+
+    @Test
+    @DisplayName("토큰 저장")
+    void save(){
+        //given
+        Token expected = new Token(1L, "kakao", "1234", 360000, "5678",
+            360000);
+
+        //when
+        Token actual = tokenRepository.save(token);
+
+        //then
+        assertThat(actual.getAccessToken()).isEqualTo(expected.getAccessToken());
+    }
+
+    @Test
+    @DisplayName("회원 아이디와 sns로 토큰 찾기")
+    void findByUserIdAndSns(){
+        //given
+        Token expected = new Token(1L, "kakao", "1234", 360000, "5678",
+            360000);
+        tokenRepository.save(token);
+
+        //when
+        Token actual = tokenRepository.findByUserIdAndSns(1L, "kakao");
+
+        //then
+        assertThat(actual.getAccessToken()).isEqualTo(expected.getAccessToken());
+    }
+
+    @Test
+    @DisplayName("회원 아이디와 sns로 존재 여부 확인 시 존재함")
+    void existsByUserIdAndSns(){
+        //given
+        Token expected = new Token(1L, "kakao", "1234", 360000, "5678",
+            360000);
+        tokenRepository.save(token);
+
+        //when
+        boolean actual = tokenRepository.existsByUserIdAndSns(1L, "kakao");
+
+        //then
+        assertThat(actual).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("회원 아이디와 sns로 존재 여부 확인 시 존재하지 않음")
+    void notExistsByUserIdAndSns(){
+        //given
+        Token expected = new Token(1L, "kakao", "1234", 360000, "5678",
+            360000);
+        tokenRepository.save(token);
+
+        //when
+        boolean actual = tokenRepository.existsByUserIdAndSns(2L, "kakao");
+
+        //then
+        assertThat(actual).isEqualTo(false);
+    }
+}

--- a/src/test/java/gift/repository/UserRepositoryTest.java
+++ b/src/test/java/gift/repository/UserRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import gift.users.user.User;
 import gift.users.user.UserRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,14 +20,14 @@ public class UserRepositoryTest {
 
     @BeforeEach
     void beforeEach(){
-        user = new User("admin@email.com", "1234");
+        user = new User("admin@email.com", "1234", "local");
     }
 
     @Test
     @DisplayName("회원 추가 테스트")
     void save() {
         //Given
-        User expected = new User("admin@email.com", "1234");
+        User expected = new User("admin@email.com", "1234", "local");
 
         //When
         User actual = userRepository.save(user);
@@ -34,6 +35,65 @@ public class UserRepositoryTest {
         //Then
         assertThat(actual.getEmail()).isEqualTo(expected.getEmail());
         assertThat(actual.getPassword()).isEqualTo(expected.getPassword());
+    }
+
+    @Test
+    @DisplayName("회원 아이디로 회원 찾기")
+    void findById() {
+        //Given
+        userRepository.save(user);
+        User expected = new User("admin@email.com", "1234", "local");
+
+        //When
+        Optional<User> actual = userRepository.findById(user.getId());
+
+        //Then
+        assertThat(actual).isPresent();
+        assertThat(actual.get())
+            .extracting(User::getEmail, User::getPassword)
+            .containsExactly(expected.getEmail(), expected.getPassword());
+    }
+
+    @Test
+    @DisplayName("회원 이메일로 회원 찾기")
+    void findByEmail() {
+        //Given
+        userRepository.save(user);
+        User expected = new User("admin@email.com", "1234", "local");
+
+        //When
+        User actual = userRepository.findByEmail(user.getEmail());
+
+        //Then
+        assertThat(actual)
+            .extracting(User::getEmail, User::getPassword)
+            .containsExactly(expected.getEmail(), expected.getPassword());
+    }
+
+    @Test
+    @DisplayName("회원 이메일로 존재 여부 확인 시 존재함")
+    void existsByEmail() {
+        //Given
+        userRepository.save(user);
+
+        //When
+        boolean actual = userRepository.existsByEmail(user.getEmail());
+
+        //Then
+        assertThat(actual).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 회원을 찾으면 false 리턴")
+    void notExistsByEmail() {
+        //Given
+        userRepository.save(user);
+
+        //When
+        boolean actual = userRepository.existsByEmail("example@email.com");
+
+        //Then
+        assertThat(actual).isEqualTo(false);
     }
 
     @Test
@@ -64,28 +124,47 @@ public class UserRepositoryTest {
     }
 
     @Test
-    @DisplayName("회원 이메일로 찾기")
-    void existsByEmail() {
+    @DisplayName("소셜 아이디와 소셜 이름으로 회원 존재 여부 확인 시 존재함")
+    void existsBySnsIdAndSns(){
         //Given
-        userRepository.save(user);
+        User kakaoUser = new User("123", "kakao");
+        userRepository.save(kakaoUser);
 
         //When
-        boolean actual = userRepository.existsByEmail(user.getEmail());
+        boolean actual = userRepository.existsBySnsIdAndSns(kakaoUser.getSnsId(), kakaoUser.getSns());
 
         //Then
         assertThat(actual).isEqualTo(true);
     }
 
     @Test
-    @DisplayName("존재하지 않는 이메일로 회원을 찾으면 false 리턴")
-    void notExistsByEmail() {
+    @DisplayName("소셜 아이디와 소셜 이름으로 회원 존재 여부 확인 시 존재하지 않음")
+    void notExistsBySnsIdAndSns(){
         //Given
-        userRepository.save(user);
+        User kakaoUser = new User("123", "kakao");
+        userRepository.save(kakaoUser);
 
         //When
-        boolean actual = userRepository.existsByEmail("example@email.com");
+        boolean actual = userRepository.existsBySnsIdAndSns("555", "kakao");
 
         //Then
         assertThat(actual).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("소셜 아이디와 소셜 이름으로 회원 찾기")
+    void findBySnsIdAndSns(){
+        //Given
+        User kakaoUser = new User("123", "kakao");
+        userRepository.save(kakaoUser);
+        User expected = new User("123", "kakao");
+
+        //When
+        User actual = userRepository.findBySnsIdAndSns(kakaoUser.getSnsId(), kakaoUser.getSns());
+
+        //Then
+        assertThat(actual)
+            .extracting(User::getSnsId, User::getSns)
+            .containsExactly(expected.getSnsId(), expected.getSns());
     }
 }

--- a/src/test/java/gift/service/CategoryServiceTest.java
+++ b/src/test/java/gift/service/CategoryServiceTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -25,22 +28,25 @@ public class CategoryServiceTest {
 
     private CategoryService categoryService;
     private final CategoryRepository categoryRepository = mock(CategoryRepository.class);
+    private Category category;
+    private CategoryDTO categoryDTO;
 
     @BeforeEach
     void beforeEach() {
         categoryService = new CategoryService(categoryRepository);
+        category = new Category("상품권", "#ff11ff", "image.jpg", "");
+        categoryDTO = new CategoryDTO("상품권", "#ff11ff", "image.jpg", "");
     }
 
     @Test
     @DisplayName("카테고리 전체 조회 테스트")
     void getAllCategories() {
         //given
-        Category category = new Category(1L, "상품권", "#ff11ff", "image.jpg", "");
-        Category category1 = new Category(2L, "인형", "#dd11ff", "image.jpg", "none");
+        Category category1 = new Category("인형", "#dd11ff", "image.jpg", "none");
         given(categoryRepository.findAll()).willReturn(
             Arrays.asList(category, category1));
-        CategoryDTO expected = new CategoryDTO(1L, "상품권", "#ff11ff", "image.jpg", "");
-        CategoryDTO expected1 = new CategoryDTO(2L, "인형", "#dd11ff", "image.jpg", "none");
+        CategoryDTO expected = new CategoryDTO("상품권", "#ff11ff", "image.jpg", "");
+        CategoryDTO expected1 = new CategoryDTO("인형", "#dd11ff", "image.jpg", "none");
 
         //when
         List<CategoryDTO> actual = categoryService.getAllCategories();
@@ -48,10 +54,13 @@ public class CategoryServiceTest {
         //then
         assertThat(actual).hasSize(2);
         assertThat(actual)
-            .extracting(CategoryDTO::getName, CategoryDTO::getColor, CategoryDTO::getImageUrl, CategoryDTO::getDescription)
+            .extracting(CategoryDTO::getName, CategoryDTO::getColor, CategoryDTO::getImageUrl,
+                CategoryDTO::getDescription)
             .containsExactly(
-                tuple(expected.getName(), expected.getColor(), expected.getImageUrl(), expected.getDescription()),
-                tuple(expected1.getName(), expected1.getColor(), expected1.getImageUrl(), expected1.getDescription())
+                tuple(expected.getName(), expected.getColor(), expected.getImageUrl(),
+                    expected.getDescription()),
+                tuple(expected1.getName(), expected1.getColor(), expected1.getImageUrl(),
+                    expected1.getDescription())
             );
     }
 
@@ -59,12 +68,12 @@ public class CategoryServiceTest {
     @DisplayName("아이디로 카테고리 검색")
     void getCategoryById() {
         //given
-        CategoryDTO expected = new CategoryDTO(2L, "인형", "#dd11ff", "image.jpg", "none");
         given(categoryRepository.findById(any())).willReturn(
-            Optional.of(new Category(2L, "인형", "#dd11ff", "image.jpg", "none")));
+            Optional.of(category));
+        CategoryDTO expected = new CategoryDTO("상품권", "#ff11ff", "image.jpg", "");
 
         //when
-        CategoryDTO actual = categoryService.getCategoryById(2L);
+        CategoryDTO actual = categoryService.getCategoryById(1L);
 
         //then
         assertThat(actual)
@@ -83,16 +92,15 @@ public class CategoryServiceTest {
         //when
 
         //then
-        assertThatThrownBy(() -> categoryService.getCategoryById(2L)).isInstanceOf(
+        assertThatThrownBy(() -> categoryService.getCategoryById(1L)).isInstanceOf(
             NotFoundIdException.class).hasMessageContaining("카테고리 아이디를 찾을 수 없습니다.");
     }
 
     @Test
-    @DisplayName("카테고리 추가 시 이름 존재하면 오류")
+    @DisplayName("카테고리 추가 시 이미 존재하는 이름이면 오류")
     void addCategorySameNameError() {
         //given
         given(categoryRepository.existsByName(any())).willReturn(true);
-        CategoryDTO categoryDTO = new CategoryDTO("이름", "색상", "이미지링크", "설명");
 
         //when
 
@@ -102,12 +110,11 @@ public class CategoryServiceTest {
     }
 
     @Test
-    @DisplayName("카테고리 추가")
+    @DisplayName("카테고리 추가 성공")
     void addCategory() {
         //given
-        CategoryDTO categoryDTO = new CategoryDTO(1L, "이름", "색상", "이미지링크", "설명");
         given(categoryRepository.existsByName(any())).willReturn(false);
-        given(categoryRepository.save(any())).willReturn(categoryDTO.toCategory());
+        given(categoryRepository.save(any())).willReturn(category);
 
         //when
         categoryService.addCategory(categoryDTO);
@@ -121,12 +128,11 @@ public class CategoryServiceTest {
     void updateCategoryNotFoundException() {
         //given
         given(categoryRepository.findById(1L)).willReturn(Optional.empty());
-        CategoryDTO categoryDTO = new CategoryDTO(1L, "상품권", "#11ff11", null, null);
 
         //when
 
         //then
-        assertThatThrownBy(() -> categoryService.updateCategory(categoryDTO)).isInstanceOf(
+        assertThatThrownBy(() -> categoryService.updateCategory(categoryDTO, 1L)).isInstanceOf(
             NotFoundIdException.class).hasMessageContaining("카테고리 아이디를 찾을 수 없습니다.");
     }
 
@@ -134,51 +140,101 @@ public class CategoryServiceTest {
     @DisplayName("카테고리 업데이트 존재하는 이름일 때 오류")
     void updateCategoryExistingName() {
         //given
-        CategoryDTO categoryDTO = new CategoryDTO(1L, "상품권", "#ff11ff", null, null);
-        given(categoryRepository.findById(1L)).willReturn(Optional.of(categoryDTO.toCategory()));
-        given(categoryRepository.existsByNameAndIdNot(categoryDTO.getName(),
-            categoryDTO.getId())).willReturn(true);
+        given(categoryRepository.findById(any())).willReturn(Optional.of(category));
+        given(categoryRepository.existsByNameAndIdNot(anyString(), anyLong())).willReturn(true);
 
         //when
 
         //then
         assertThatIllegalArgumentException().isThrownBy(
-            () -> categoryService.updateCategory(categoryDTO)).withMessage("존재하는 이름입니다.");
+            () -> categoryService.updateCategory(categoryDTO, 1L)).withMessage("존재하는 이름입니다.");
     }
 
     @Test
-    @DisplayName("카테고리 업데이트")
+    @DisplayName("카테고리 업데이트 성공")
     void updateCategory() {
         //given
-        CategoryDTO categoryDTO = new CategoryDTO(1L, "상품권", "#ff11ff", null, null);
-        CategoryDTO categoryDTO1 = new CategoryDTO(1L, "인형", "#ff11ff", "image.url", "dolls");
-        given(categoryRepository.findById(1L)).willReturn(Optional.of(categoryDTO.toCategory()));
+        given(categoryRepository.findById(1L)).willReturn(Optional.of(category));
         given(categoryRepository.existsByName(any())).willReturn(false);
-        given(categoryRepository.save(any())).willReturn(categoryDTO.toCategory());
+        given(categoryRepository.save(any())).willReturn(category);
 
         //when
-        categoryService.updateCategory(categoryDTO1);
+        categoryService.updateCategory(categoryDTO, 1L);
 
         //then
         then(categoryRepository).should().save(any());
     }
 
     @Test
+    @DisplayName("카테고리 이름 존재함 Exception 던짐")
+    void existsByNameThrowException() {
+        //given
+        given(categoryRepository.existsByName(anyString())).willReturn(true);
+
+        //when
+
+        //then
+        assertThatIllegalArgumentException().isThrownBy(
+            () -> categoryService.existsByNameThrowException("도서"))
+            .withMessage("존재하는 이름입니다.");
+    }
+
+    @Test
+    @DisplayName("카테고리 이름 존재하지 않음 Exception 던지지 않음")
+    void notExistingByNameNotThrowException() {
+        //given
+        given(categoryRepository.existsByName(anyString())).willReturn(false);
+
+        //when
+
+        //then
+        assertDoesNotThrow(() -> categoryService.existsByNameThrowException("라면"));
+    }
+
+    @Test
+    @DisplayName("카테고리 이름 존재하고 아이디는 다름 Exception 던짐")
+    void existsByNameAndIdThrowException() {
+        //given
+        given(categoryRepository.existsByName(anyString())).willReturn(true);
+        given(categoryRepository.findById(any())).willReturn(Optional.ofNullable(category));
+
+        //when
+
+        //then
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> categoryService.existsByNameThrowException("상품권"))
+            .withMessage("존재하는 이름입니다.");
+    }
+
+    @Test
+    @DisplayName("카테고리 이름 존재하지 않거나 존재하지만 아이디가 같음 Exception 던지지 않음")
+    void existsByNameAndIdNotThrowException() {
+        //given
+        given(categoryRepository.existsByName(anyString())).willReturn(false);
+        given(categoryRepository.findById(any())).willReturn(Optional.ofNullable(category));
+
+        //when
+
+        //then
+        assertDoesNotThrow(() -> categoryService.existsByNameAndId("라면", 1L));
+    }
+
+    @Test
     @DisplayName("카테고리 삭제")
     void deleteCategory() {
         //given
-        given(categoryRepository.existsById(1L)).willReturn(true);
+        given(categoryRepository.existsById(anyLong())).willReturn(true);
 
         //when
         categoryService.deleteCategory(1L);
 
         //then
-        then(categoryRepository).should().deleteById(1L);
+        then(categoryRepository).should().deleteById(any());
     }
 
     @Test
     @DisplayName("카테고리 삭제시 아이디가 없는 오류")
-    void deleteCategoryNotFoundException() {
+    void deleteCategoryNotFoundIdException() {
         //given
         given(categoryRepository.findById(any())).willReturn(Optional.empty());
 

--- a/src/test/java/gift/service/KakaoAuthServiceTest.java
+++ b/src/test/java/gift/service/KakaoAuthServiceTest.java
@@ -2,8 +2,12 @@ package gift.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -11,8 +15,10 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import gift.error.KakaoAuthenticationException;
+import gift.token.TokenService;
 import gift.users.kakao.KakaoAuthService;
 import gift.users.kakao.KakaoProperties;
+import gift.users.kakao.KakaoTokenDTO;
 import gift.users.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +38,7 @@ public class KakaoAuthServiceTest {
     private KakaoAuthService kakaoAuthService;
     private UserService userService = mock(UserService.class);
     private RestClient.Builder restClientBuilder;
+    private TokenService tokenService = mock(TokenService.class);
     @Autowired
     private KakaoProperties kakaoProperties;
 
@@ -47,7 +54,7 @@ public class KakaoAuthServiceTest {
             });
         server = MockRestServiceServer.bindTo(restClientBuilder).build();
         kakaoAuthService = new KakaoAuthService(kakaoProperties, restClientBuilder,
-            userService);
+            userService, tokenService);
     }
 
     @Test
@@ -66,8 +73,9 @@ public class KakaoAuthServiceTest {
             .andExpect(method(POST))
             .andRespond(withSuccess(userResponse, MediaType.APPLICATION_JSON));
 
-        when(userService.findByKakaoIdAndRegisterIfNotExists("1")).thenReturn(1L);
-        when(userService.loginGiveJwt("1")).thenReturn("user_token");
+        given(userService.findBySnsIdAndSnsAndRegisterIfNotExists(anyString(), anyString())).willReturn(1L);
+        given(userService.loginGiveJwt(anyString())).willReturn("user_token");
+        doNothing().when(tokenService).saveToken(anyLong(), any(KakaoTokenDTO.class), anyString());
 
         //when
         String result = kakaoAuthService.kakaoCallBack(code);

--- a/src/test/java/gift/service/KakaoAuthServiceTest.java
+++ b/src/test/java/gift/service/KakaoAuthServiceTest.java
@@ -67,7 +67,7 @@ public class KakaoAuthServiceTest {
             .andRespond(withSuccess(userResponse, MediaType.APPLICATION_JSON));
 
         when(userService.findByKakaoIdAndRegisterIfNotExists("1")).thenReturn(1L);
-        when(userService.loginGiveToken("1")).thenReturn("user_token");
+        when(userService.loginGiveJwt("1")).thenReturn("user_token");
 
         //when
         String result = kakaoAuthService.kakaoCallBack(code);

--- a/src/test/java/gift/service/KakaoOrderServiceTest.java
+++ b/src/test/java/gift/service/KakaoOrderServiceTest.java
@@ -1,0 +1,158 @@
+package gift.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import gift.administrator.option.OptionDTO;
+import gift.administrator.option.OptionService;
+import gift.administrator.product.ProductDTO;
+import gift.administrator.product.ProductService;
+import gift.error.KakaoOrderException;
+import gift.token.TokenService;
+import gift.users.kakao.KakaoOrderDTO;
+import gift.users.kakao.KakaoOrderService;
+import gift.users.kakao.KakaoProperties;
+import gift.users.wishlist.WishListService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class KakaoOrderServiceTest {
+
+    private MockRestServiceServer server;
+    private KakaoOrderService kakaoOrderService;
+    private TokenService tokenService = mock(TokenService.class);
+    private ProductService productService = mock(ProductService.class);
+    private OptionService optionService = mock(OptionService.class);
+    private RestClient.Builder restClientBuilder;
+    @Autowired
+    private KakaoProperties kakaoProperties;
+    private WishListService wishListService = mock(WishListService.class);
+
+    @BeforeEach
+    void beforeEach() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(10000);
+        restClientBuilder = RestClient.builder()
+            .requestFactory(factory)
+            .defaultHeaders(headers -> {
+                headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+            });
+        server = MockRestServiceServer.bindTo(restClientBuilder).build();
+        kakaoOrderService = new KakaoOrderService(tokenService, productService,
+            optionService, restClientBuilder, kakaoProperties, wishListService);
+    }
+
+    @Test
+    @DisplayName("카카오 주문 성공")
+    void kakaoOrder() {
+        //given
+        given(productService.existsByProductId(anyLong())).willReturn(false);
+        OptionDTO optionDTO = new OptionDTO("XL", 3, 1L);
+        given(optionService.findOptionById(anyLong())).willReturn(optionDTO);
+
+        doNothing().when(optionService)
+            .subtractOptionQuantityErrorIfNotPossible(anyLong(), anyInt());
+        given(tokenService.findToken(anyLong(), anyString())).willReturn("access-token");
+
+        ProductDTO productDTO = new ProductDTO(1L, "신라면", 3000, "imageUrl", 1L, null);
+        given(productService.getProductById(anyLong())).willReturn(productDTO);
+        given(optionService.findOptionById(anyLong())).willReturn(optionDTO);
+
+        server.expect(requestTo(kakaoProperties.sendToMeUrl()))
+            .andExpect(method(POST))
+            .andRespond(withSuccess("0", MediaType.APPLICATION_JSON));
+
+        given(optionService.subtractOptionQuantity(anyLong(), anyInt())).willReturn(null);
+        doNothing().when(wishListService)
+            .findOrderAndDeleteIfExists(anyLong(), anyLong(), anyLong());
+        KakaoOrderDTO kakaoOrderDTO = new KakaoOrderDTO(1L, 1L,
+            3, null, "안녕하세요");
+        KakaoOrderDTO expected = new KakaoOrderDTO(1L, 1L,
+            3, "2024-10-23", "안녕하세요");
+
+        //when
+        KakaoOrderDTO result = kakaoOrderService.kakaoOrder(1L, kakaoOrderDTO, "2024-10-23");
+
+        //then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("카카오 주문 시 없는 상품 주문하면 Exception 발생")
+    void kakaoOrderFailNotExistingProduct() {
+        //given
+        given(productService.existsByProductId(anyLong())).willReturn(true);
+        KakaoOrderDTO kakaoOrderDTO = new KakaoOrderDTO(1L, 1L,
+            3, null, "안녕하세요");
+
+        //when
+
+        //then
+        assertThatThrownBy(() -> kakaoOrderService.kakaoOrder(1L, kakaoOrderDTO, "2024-10-23"))
+            .isInstanceOf(KakaoOrderException.class).hasMessageContaining("없는 상품입니다.");
+    }
+
+    @Test
+    @DisplayName("카카오 주문 시 상품에 없는 옵션 주문시 exception 발생")
+    void kakaoOrderFailNotExistingOptionInProduct() {
+        //given
+        given(productService.existsByProductId(anyLong())).willReturn(false);
+
+        OptionDTO optionDTO = new OptionDTO("XL", 3, 1L);
+        given(optionService.findOptionById(anyLong())).willReturn(optionDTO);
+
+        KakaoOrderDTO kakaoOrderDTO = new KakaoOrderDTO(2L, 1L,
+            3, null, "안녕하세요");
+
+        //when
+
+        //then
+        assertThatThrownBy(() -> kakaoOrderService.kakaoOrder(1L, kakaoOrderDTO, "2024-10-23"))
+            .isInstanceOf(KakaoOrderException.class)
+            .hasMessageContaining(kakaoOrderDTO.productId() +
+                " 상품에 " + kakaoOrderDTO.optionId() + " 옵션이 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("카카오 주문 시 옵션 재고가 부족함")
+    void kakaoOrderFailCannotSubtract() {
+        //given
+        given(productService.existsByProductId(anyLong())).willReturn(false);
+
+        OptionDTO optionDTO = new OptionDTO("XL", 3, 1L);
+        given(optionService.findOptionById(anyLong())).willReturn(optionDTO);
+
+        KakaoOrderDTO kakaoOrderDTO = new KakaoOrderDTO(1L, 1L,
+            3, null, "안녕하세요");
+
+        doThrow(new IllegalArgumentException("옵션의 재고가 부족합니다."))
+            .when(optionService).subtractOptionQuantityErrorIfNotPossible(anyLong(), anyInt());
+
+        //when
+
+        //then
+        assertThatThrownBy(() -> kakaoOrderService.kakaoOrder(1L, kakaoOrderDTO, "2024-10-23"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("옵션의 재고가 부족합니다.");
+    }
+}

--- a/src/test/java/gift/service/OptionServiceTest.java
+++ b/src/test/java/gift/service/OptionServiceTest.java
@@ -4,6 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -35,14 +39,14 @@ public class OptionServiceTest {
     void beforeEach() {
         optionService = new OptionService(optionRepository);
         Category category = new Category("상품권", null, null, null);
-        option = new Option(1L, "L", 3, null);
+        option = new Option("L", 3, null);
         List<Option> options = new ArrayList<>(List.of(option));
-        Product product = new Product(1L, "라이언", 1000, "image.jpg", category, options);
-        option1 = new Option(2L, "XL", 5, null);
+        Product product = new Product("라이언", 1000, "image.jpg", category, options);
+        option1 = new Option("XL", 5, null);
         option.setProduct(product);
         option1.setProduct(product);
-        expected = new OptionDTO(1L, "L", 3, product.getId());
-        expected1 = new OptionDTO(2L, "XL", 5, product.getId());
+        expected = new OptionDTO("L", 3, null);
+        expected1 = new OptionDTO("XL", 5, null);
     }
 
     @Test
@@ -56,31 +60,27 @@ public class OptionServiceTest {
 
         //then
         assertThat(actual).hasSize(2);
-        assertThat(actual)
-            .extracting(OptionDTO::getName, OptionDTO::getQuantity, OptionDTO::getProductId)
-            .containsExactly(
-                tuple(expected.getName(), expected.getQuantity(), expected.getProductId()),
-                tuple(expected1.getName(), expected1.getQuantity(), expected1.getProductId())
-            );
+        assertThat(actual).extracting(OptionDTO::getName, OptionDTO::getQuantity,
+            OptionDTO::getProductId).containsExactly(
+            tuple(expected.getName(), expected.getQuantity(), expected.getProductId()),
+            tuple(expected1.getName(), expected1.getQuantity(), expected1.getProductId()));
     }
 
     @Test
     @DisplayName("상품 아이디로 옵션 전체 조회 테스트")
     void getAllOptionsByProductId() {
         //given
-        given(optionRepository.findAllByProductId(1L)).willReturn(List.of(option, option1));
+        given(optionRepository.findAllByProductId(anyLong())).willReturn(List.of(option, option1));
 
         //when
         List<OptionDTO> actual = optionService.getAllOptionsByProductId(1L);
 
         //then
         assertThat(actual).hasSize(2);
-        assertThat(actual)
-            .extracting(OptionDTO::getName, OptionDTO::getQuantity, OptionDTO::getProductId)
-            .containsExactly(
-                tuple(expected.getName(), expected.getQuantity(), expected.getProductId()),
-                tuple(expected1.getName(), expected1.getQuantity(), expected1.getProductId())
-            );
+        assertThat(actual).extracting(OptionDTO::getName, OptionDTO::getQuantity,
+            OptionDTO::getProductId).containsExactly(
+            tuple(expected.getName(), expected.getQuantity(), expected.getProductId()),
+            tuple(expected1.getName(), expected1.getQuantity(), expected1.getProductId()));
     }
 
     @Test
@@ -94,19 +94,45 @@ public class OptionServiceTest {
 
         //then
         assertThat(actual).hasSize(2);
-        assertThat(actual)
-            .extracting(OptionDTO::getName, OptionDTO::getQuantity, OptionDTO::getProductId)
-            .containsExactly(
-                tuple(expected.getName(), expected.getQuantity(), expected.getProductId()),
-                tuple(expected1.getName(), expected1.getQuantity(), expected1.getProductId())
-            );
+        assertThat(actual).extracting(OptionDTO::getName, OptionDTO::getQuantity,
+            OptionDTO::getProductId).containsExactly(
+            tuple(expected.getName(), expected.getQuantity(), expected.getProductId()),
+            tuple(expected1.getName(), expected1.getQuantity(), expected1.getProductId()));
+    }
+
+    @Test
+    @DisplayName("옵션 아이디와 상품 아이디로 존재 여부 확인 시 존재함")
+    void findOptionById() {
+        //given
+        given(optionRepository.findById(anyLong())).willReturn(Optional.ofNullable(option));
+
+        //when
+        OptionDTO actual = optionService.findOptionById(1L);
+
+        //then
+        assertThat(actual).extracting(OptionDTO::getName, OptionDTO::getQuantity,
+                OptionDTO::getProductId)
+            .containsExactly(expected.getName(), expected.getQuantity(), expected.getProductId());
+    }
+
+    @Test
+    @DisplayName("옵션 아이디와 상품 아이디로 존재 여부 확인 시 존재하지 않음")
+    void findOptionByIdNotFound() {
+        //given
+        given(optionRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        //when
+
+        //then
+        assertThatThrownBy(() -> optionService.findOptionById(1L)).isInstanceOf(
+            NotFoundIdException.class).hasMessageContaining("아이디를 찾을 수 없습니다.");
     }
 
     @Test
     @DisplayName("옵션 아이디와 상품 아이디로 존재 여부 확인 시 존재함")
     void existsByOptionIdAndProductId() {
         //given
-        given(optionRepository.existsByIdAndProductId(1L, 1L)).willReturn(true);
+        given(optionRepository.existsByIdAndProductId(anyLong(), anyLong())).willReturn(true);
 
         //when
         boolean actual = optionService.existsByOptionIdAndProductId(1L, 1L);
@@ -119,7 +145,7 @@ public class OptionServiceTest {
     @DisplayName("옵션 아이디와 상품 아이디로 존재 여부 확인 시 존재하지 않음")
     void notExistsByOptionIdAndProductId() {
         //given
-        given(optionRepository.existsByIdAndProductId(1L, 1L)).willReturn(false);
+        given(optionRepository.existsByIdAndProductId(anyLong(), anyLong())).willReturn(false);
 
         //when
         boolean actual = optionService.existsByOptionIdAndProductId(1L, 1L);
@@ -129,13 +155,60 @@ public class OptionServiceTest {
     }
 
     @Test
-    @DisplayName("옵션 아이디와 상품 아이디로 존재 여부 확인 시 존재함")
-    void findOptionById() {
+    @DisplayName("옵션 이름과 상품 아이디가 같지만 옵션 아이디는 다를 때 throw하지 않음")
+    void existsByNameSameProductIdNotOptionId() {
         //given
-        given(optionRepository.findById(1L)).willReturn(Optional.ofNullable(option));
+        given(optionRepository.existsByNameAndProductIdAndIdNot(anyString(), anyLong(),  anyLong()))
+            .willReturn(false);
 
         //when
-        OptionDTO actual = optionService.findOptionById(1L);
+
+        //then
+        assertDoesNotThrow(() -> optionService.existsByNameSameProductIdNotOptionId("라면", 1L, 1L));
+    }
+
+    @Test
+    @DisplayName("옵션 이름과 상품 아이디가 다르거나 옵션 아이디가 같을 때 throw")
+    void existsByNameSameProductIdNotOptionIdThrowsException() {
+        //given
+        given(optionRepository.existsByNameAndProductIdAndIdNot(anyString(), anyLong(), anyLong()))
+            .willReturn(true);
+
+        //when
+
+        //then
+        assertThatIllegalArgumentException().isThrownBy(
+            () -> optionService.existsByNameSameProductIdNotOptionId("라면", 1L, 1L))
+            .withMessage("같은 상품 내에서 동일한 이름의 옵션은 불가합니다.");
+    }
+
+    @Test
+    @DisplayName("옵션 아이디로 찾은 상품 아이디로 모든 옵션 찾기")
+    void countAllOptionsByProductIdFromOptionId() {
+        //given
+        given(optionRepository.findById(anyLong()))
+            .willReturn(Optional.ofNullable(option));
+        given(optionRepository.countAllByProductId(any()))
+            .willReturn(2);
+
+        //when
+        int actual = optionService.countAllOptionsByProductIdFromOptionId(1L);
+
+        //then
+        assertThat(actual).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("옵션 업데이트 하기 성공")
+    void updateOption() {
+        //given
+        given(optionRepository.findById(anyLong()))
+            .willReturn(Optional.ofNullable(option));
+        given(optionRepository.save(any(Option.class)))
+            .willReturn(option);
+
+        //when
+        OptionDTO actual = optionService.updateOption(1L, OptionDTO.fromOption(option));
 
         //then
         assertThat(actual)
@@ -144,51 +217,26 @@ public class OptionServiceTest {
     }
 
     @Test
-    @DisplayName("옵션 아이디와 상품 아이디로 존재 여부 확인 시 존재하지 않음")
-    void findOptionByIdNotFound() {
+    @DisplayName("옵션 업데이트 시도 중 없는 옵션 아이디로 시도하여 exception 발생")
+    void updateOptionThrowsExceptionWhenOptionIdNotFound() {
         //given
-        given(optionRepository.findById(1L)).willReturn(Optional.empty());
+        given(optionRepository.findById(anyLong()))
+            .willReturn(Optional.empty());
 
         //when
 
         //then
-        assertThatThrownBy(() -> optionService.findOptionById(1L)).isInstanceOf(
-            NotFoundIdException.class).hasMessageContaining("아이디를 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("옵션 아이디로 옵션 삭제")
-    void deleteOptionByOptionId() {
-        //given
-        given(optionRepository.existsById(1L)).willReturn(true);
-        given(optionRepository.findById(1L)).willReturn(Optional.ofNullable(option));
-
-        //when
-        optionService.deleteOptionByOptionId(1L);
-
-        //then
-        then(optionRepository).should().deleteById(1L);
-    }
-
-    @Test
-    @DisplayName("옵션 아이디로 옵션 삭제시 존재하지 않는 아이디로 삭제 시도")
-    void deleteOptionByOptionIdIdNotFound() {
-        //given
-        given(optionRepository.existsById(1L)).willReturn(false);
-
-        //when
-
-        //then
-        assertThatIllegalArgumentException().isThrownBy(
-            () -> optionService.deleteOptionByOptionId(1L)).withMessage("없는 아이디입니다.");
+        assertThatThrownBy(() -> optionService.countAllOptionsByProductIdFromOptionId(1L))
+            .isInstanceOf(NotFoundIdException.class)
+            .hasMessageContaining("옵션 아이디를 찾을 수 없습니다.");
     }
 
     @Test
     @DisplayName("옵션 수량 차감 성공")
     void subtractOptionQuantity() {
         //given
-        given(optionRepository.findById(1L)).willReturn(Optional.ofNullable(option));
-        Option expected = new Option(1L, "L", 1, null);
+        given(optionRepository.findById(anyLong())).willReturn(Optional.ofNullable(option));
+        Option expected = new Option("L", 1, null);
 
         //when
         Option actual = optionService.subtractOptionQuantity(1L, 2);
@@ -198,21 +246,21 @@ public class OptionServiceTest {
     }
 
     @Test
-    @DisplayName("옵션 수량 차감 시도 중 아이디 찾기 실패")
+    @DisplayName("옵션 수량 차감 시도 중 옵션 아이디 찾기 실패")
     void subtractOptionQuantityIdNotFound() {
         //given
-        given(optionRepository.findById(1L)).willReturn(Optional.empty());
+        given(optionRepository.findById(anyLong())).willReturn(Optional.empty());
 
         //when
 
         //then
         assertThatThrownBy(() -> optionService.subtractOptionQuantity(1L, 2)).isInstanceOf(
-            NotFoundIdException.class).hasMessageContaining("아이디를 찾을 수 없습니다.");
+            NotFoundIdException.class).hasMessageContaining("옵션 아이디를 찾을 수 없습니다.");
     }
 
     @Test
     @DisplayName("옵션 수량 차감 시도 중 옵션 수량보다 차감하려는 수량이 더 많을 때")
-    void subtractOptionQuantityNotEnoughQuantity() {
+    void subtractOptionQuantityErrorIfNotPossible() {
         //given
         given(optionRepository.findById(1L)).willReturn(Optional.ofNullable(option));
 
@@ -220,6 +268,34 @@ public class OptionServiceTest {
 
         //then
         assertThatIllegalArgumentException().isThrownBy(
-            () -> optionService.subtractOptionQuantity(1L, 4)).withMessage("옵션의 수량이 부족합니다.");
+                () -> optionService.subtractOptionQuantityErrorIfNotPossible(1L, 10))
+            .withMessage("옵션의 재고가 부족합니다.");
+    }
+
+    @Test
+    @DisplayName("옵션 아이디로 옵션 삭제")
+    void deleteOptionByOptionId() {
+        //given
+        given(optionRepository.existsById(anyLong())).willReturn(true);
+        given(optionRepository.findById(anyLong())).willReturn(Optional.ofNullable(option));
+
+        //when
+        optionService.deleteOptionByOptionId(1L);
+
+        //then
+        then(optionRepository).should().deleteById(any());
+    }
+
+    @Test
+    @DisplayName("옵션 아이디로 옵션 삭제시 존재하지 않는 아이디로 삭제 시도")
+    void deleteOptionByOptionIdIdNotFound() {
+        //given
+        given(optionRepository.existsById(anyLong())).willReturn(false);
+
+        //when
+
+        //then
+        assertThatThrownBy(() -> optionService.deleteOptionByOptionId(1L)).isInstanceOf(
+            NotFoundIdException.class).hasMessageContaining("옵션 아이디를 찾을 수 없습니다.");
     }
 }

--- a/src/test/java/gift/service/ProductServiceTest.java
+++ b/src/test/java/gift/service/ProductServiceTest.java
@@ -1,0 +1,79 @@
+package gift.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import gift.administrator.category.Category;
+import gift.administrator.category.CategoryService;
+import gift.administrator.option.Option;
+import gift.administrator.product.Product;
+import gift.administrator.product.ProductDTO;
+import gift.administrator.product.ProductRepository;
+import gift.administrator.product.ProductService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class ProductServiceTest {
+
+    private ProductService productService;
+    private ProductRepository productRepository = mock(ProductRepository.class);
+    private CategoryService categoryService = mock(CategoryService.class);
+
+    @BeforeEach
+    void beforeEach(){
+        productService = new ProductService(productRepository, categoryService);
+    }
+
+    @Test
+    @DisplayName("상품 전체 가져오기")
+    void getAllProducts(){
+        //given
+        int page = 0;
+        int size = 10;
+        String sortBy = "name";
+        Sort.Direction direction = Sort.Direction.ASC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
+
+        Category category = new Category(1L, "도서", null, null, null);
+        Option option = new Option("어린왕자", 3, null);
+
+        Product product1 = new Product(1L, "Product1", 1000, "imageUrl1", category, null);
+        option.setProduct(product1);
+        product1.setOption(List.of(option));
+
+        Product product2 = new Product(2L, "Product2", 2000, "imageUrl2", category, null);
+        option.setProduct(product2);
+        product2.setOption(List.of(option));
+
+        ProductDTO productDTO1 = new ProductDTO(1L, "Product1", 1000, "imageUrl1", 1L, null);
+        ProductDTO productDTO2 = new ProductDTO(2L, "Product2", 2000, "imageUrl2", 1L, null);
+
+        List<Product> products = List.of(product1, product2);
+        Page<Product> productPage = new PageImpl<>(products, pageable, products.size());
+        List<ProductDTO> expected = List.of(productDTO1, productDTO2);
+
+        given(productRepository.findAll(pageable)).willReturn(productPage);
+
+        //when
+        Page<ProductDTO> result = productService.getAllProducts(page, size, sortBy, direction);
+
+        //then
+        assertThat(result.getTotalElements()).isEqualTo(expected.size());
+        assertThat(result.getContent().get(0))
+            .extracting(ProductDTO::getName, ProductDTO::getPrice, ProductDTO::getImageUrl, ProductDTO::getCategoryId)
+            .containsExactly(expected.getFirst().getName(), expected.getFirst().getPrice(),
+                expected.getFirst().getImageUrl(), expected.getFirst().getCategoryId());
+        assertThat(result.getContent().get(1))
+            .extracting(ProductDTO::getName, ProductDTO::getPrice, ProductDTO::getImageUrl, ProductDTO::getCategoryId)
+            .containsExactly(expected.get(1).getName(), expected.get(1).getPrice(),
+                expected.get(1).getImageUrl(), expected.get(1).getCategoryId());
+    }
+}

--- a/src/test/java/gift/service/TokenServiceTest.java
+++ b/src/test/java/gift/service/TokenServiceTest.java
@@ -1,0 +1,58 @@
+package gift.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import gift.token.Token;
+import gift.token.TokenRepository;
+import gift.token.TokenService;
+import gift.users.kakao.KakaoTokenDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class TokenServiceTest {
+
+    private TokenService tokenService;
+    private TokenRepository tokenRepository = mock(TokenRepository.class);
+
+    @BeforeEach
+    void beforeEach() {
+        tokenService = new TokenService(tokenRepository);
+    }
+
+    @Test
+    @DisplayName("토큰 저장")
+    void saveToken() {
+        //given
+        KakaoTokenDTO kakaoTokenDTO =
+            new KakaoTokenDTO("1", "1", 1, "1", 1);
+        given(tokenRepository.existsByUserIdAndSns(anyLong(), anyString())).willReturn(false);
+
+        //when
+        tokenService.saveToken(1L, kakaoTokenDTO, "kakao");
+
+        //then
+        then(tokenRepository).should().save(any());
+    }
+
+    @Test
+    @DisplayName("토큰 찾기")
+    void findToken() {
+        //given
+        Token token =
+            new Token(1L, "kakao", "access-token", 1, "refresh-token",1);
+        given(tokenRepository.findByUserIdAndSns(anyLong(), anyString())).willReturn(token);
+
+        //when
+        String actual = tokenService.findToken(1L,"kakao");
+
+        //then
+        assertThat(actual).isEqualTo("access-token");
+    }
+}


### PR DESCRIPTION
테스트 코드를 아직 작성하지 못했습니다. 과제 제출 기한이 다가와서 미리 올려둡니다.
테스트 코드 작성을 완료하고 다시 리뷰 요청 드리겠습니다!

### 멘토링에서 말씀해주신 부분
1. 멘토링에서 말씀드린 상품 업데이트시 DB 아이디 변경되는 문제는 해결했습니다. 원인은 category 값 설정에 있었습니다.. 부모에서 자식과의 관계를 끊고 있었습니다. 이제 정상적으로 작동합니다!
2. 말씀해주신 양방향, 단방향도 수정해두었습니다. 필요하다고 생각되는 부분은 계속 양방향으로 두었습니다.
3. Filter도 추가, 헷갈리지 않도록 변수와 메서드 이름도 변경했습니다.

### 변경사항
1. wishList에서 상품은 중복될 수 있도록 변경하였고 이에 따라 컨트롤러도 위시리스트 아이디 값으로 삭제, 수정하는 것으로 변경하였습니다. (상품, 옵션 둘다 같으면 변경 불가)

2. optionService의 subtract를 카카오 메시지를 보내는 데에 성공하면 차감할 수 있도록 설정했습니다.
subtract 메서드 안에 있던, `옵션 수량보다 많은 요청을 하면 에러 메시지를 띄우는 부분`은 따로 다른 메서드에 분리해두어 메시지를 보내기 전에 상품을 구매 가능한지 확인하도록 했습니다.
메시지를 보내는 데에 실패했을 때에는 구매가 완료되지 않도록 하기 위해 변경했습니다.

3. 토큰 저장에 관련한 클래스(entity, repository, service) 들이 카카오 폴더에 있는 것은 적절하지 않다고 생각하여 따로 토큰 폴더를 만들어 옮겼습니다.

### 진행 중
카카오 뿐만 아니라 다른 소셜미디어와도 연결했을 때 사용할 수 있도록 메서드를 변경하고 있습니다. 테스트 추가하면서 같이 추가하겠습니다.